### PR TITLE
[feat] timeline 페이지를 아래로 잡아내리면 갱신되는 기능 추가

### DIFF
--- a/fourtoon-cookie/src/pages/DiaryTimelinePage/DiaryTimelinePage.tsx
+++ b/fourtoon-cookie/src/pages/DiaryTimelinePage/DiaryTimelinePage.tsx
@@ -34,9 +34,7 @@ const DiaryTimelinePage = () => {
     }
 
     const handleEndReached = async () => {
-        if (hasMoreRef.current) {
-            setListStatus(LIST_STATUS.END_REACHED)
-        }
+        setListStatus(LIST_STATUS.END_REACHED)
     };
 
     const handleRefresh = async () => {
@@ -64,8 +62,6 @@ const DiaryTimelinePage = () => {
                     break;
             }
 
-            setListStatus(LIST_STATUS.NONE);
-
             const result = await getDiaries(pageRef.current);
 
             setDiaries([...currentDiaries, ...result]);
@@ -76,6 +72,7 @@ const DiaryTimelinePage = () => {
         }
 
         fetchDiaries(listStatus);
+        setListStatus(LIST_STATUS.NONE);
 
     }, [listStatus, diaries, pageRef, hasMoreRef]);
 

--- a/fourtoon-cookie/src/pages/DiaryTimelinePage/DiaryTimelinePage.tsx
+++ b/fourtoon-cookie/src/pages/DiaryTimelinePage/DiaryTimelinePage.tsx
@@ -34,7 +34,8 @@ const DiaryTimelinePage = () => {
     }
 
     const handleEndReached = async () => {
-        setListStatus(LIST_STATUS.END_REACHED)
+        if (!hasMoreRef.current) return;
+        setListStatus(LIST_STATUS.END_REACHED);
     };
 
     const handleRefresh = async () => {
@@ -57,7 +58,6 @@ const DiaryTimelinePage = () => {
                     currentDiaries = [];
                     break;
                 case LIST_STATUS.END_REACHED:
-                    if (!hasMoreRef.current) return;
                     pageRef.current++;
                     break;
             }
@@ -69,10 +69,11 @@ const DiaryTimelinePage = () => {
             if (result == null || result.length == 0) {
                 hasMoreRef.current = false;
             }
+
+            setListStatus(LIST_STATUS.NONE);
         }
 
         fetchDiaries(listStatus);
-        setListStatus(LIST_STATUS.NONE);
 
     }, [listStatus, diaries, pageRef, hasMoreRef]);
 


### PR DESCRIPTION
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-292
---
* 구현 내용
타임라인 화면을 끌어내리면 갱신되는 기능 추가
onfreshing, reached 변수를 각각 두어 useEffect가 새로고침할 때와 무한스크롤할 때에 대한 감지를 나눠 서로 꼬이는 문제를 해결
이때, 새로고침하는 useEffect에서 page도 감지하는 이유는 page가 0으로 되지 않은 채로 새로고침되는 현상이 발견되어 refreshing && page === 0 조건이 되야 동작하도록 하기 위함

* 추가 발생한 문제(논의 사항)

### 화면 예시
---

https://github.com/user-attachments/assets/a3ab1d04-fdca-4b95-93d6-cfb3e338105e