### PR TITLE
[bug] 프론트엔드 인증 오류 시 nullable 처리 로직 추가

### DIFF
--- a/fourtoon-cookie/src/apis/api.ts
+++ b/fourtoon-cookie/src/apis/api.ts
@@ -36,5 +36,5 @@ export const requestApi = async (url: string, method: API_METHOD_TYPE, body?: an
         }
     }
 
-    throw new ApiError('인증에 실패했습니다.', API_STATUS.UNAUTHORIZED);
+    throw new JwtError('인증에 실패했습니다.');
 }

--- a/fourtoon-cookie/src/error/errorhandler.ts
+++ b/fourtoon-cookie/src/error/errorhandler.ts
@@ -1,9 +1,16 @@
 import { Alert } from "react-native";
 import { GlobalErrorInfoType } from "../types/error";
+import { jwtManager } from "../auth/jwt";
 
 
 const handleError = (error: Error, errorType: GlobalErrorInfoType, callback?: (error: Error) => void) => {
     console.error(error);
+
+    switch(error.name) {
+        case 'JwtError':
+            jwtManager.setToken(null);
+            break;
+    }
 
     switch (errorType) {
         case GlobalErrorInfoType.ALERT:

--- a/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
+++ b/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
@@ -1,11 +1,10 @@
-import { View, TouchableOpacity, Image, Text } from "react-native";
+import { View, Image, Text } from "react-native";
 import * as S from './IntroPage.styled';
 import GoogleSignInAndSignUpButton from "./GoogleSignInAndSignUpButton/GoogleSignInAndSignUpButton";
 import type { JWTToken } from "../../types/jwt";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { RootStackParamList } from "../../constants/routing";
-import { useContext, useEffect } from "react";
-import type { Member } from "../../types/member";
+import { useState } from "react";
 import { getMember } from "../../apis/member";
 import { GlobalErrorInfoType } from "../../types/error";
 import AppleSignInAndSignUpButton from "./AppleSignInAndSignUpButton/AppleSignInAndSignUpButton";
@@ -15,6 +14,8 @@ import handleError from "../../error/errorhandler";
 
 const IntroPage = () => {
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+
+    const [ isLogined, setIsLogined ] = useState<boolean>(jwtManager.getToken() != null);
     
     const navigateByCheckingMemberExist = async () => {
         try {
@@ -32,15 +33,15 @@ const IntroPage = () => {
                     GlobalErrorInfoType.ALERT,
                     () => {
                         jwtManager.setToken(null);
+                        setIsLogined(false);
                     }
                 );
             }
         }
     }
 
-    if (jwtManager.getToken()) {
+    if (isLogined) {
         navigateByCheckingMemberExist();
-        return null;
     }
 
     const handleSignUpAndSignInSuccess = async (token: JWTToken) => {
@@ -56,10 +57,10 @@ const IntroPage = () => {
                 </View>
                 <Text style={S.styles.subtitle}>나의 하루를 그림일기로 표현해보세요</Text>
             </View>
-            <View style={S.styles.buttonsContainer}>
+            { !isLogined && <View style={S.styles.buttonsContainer}>
                 <GoogleSignInAndSignUpButton onSuccess={handleSignUpAndSignInSuccess} />
                 <AppleSignInAndSignUpButton onSuccess={handleSignUpAndSignInSuccess} />
-            </View>
+            </View> }
         </View>
     );
 }


### PR DESCRIPTION
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-327
---
* 구현 내용

프론트엔드 인증 오류 시 nullable 처리를 위해 다음 로직을 추가하였습니다.

1. IntroPage에서 jwt 확인하는 과정에서 isLogin state를 활용하도록 수정 (그리고, 로그인 된 경우 로그인 버튼 안 보이도록 구성)
2. 인증 실패시 jwt error 를 던지고, jwt error 시에는 jwt 초기화하도록 로직 수정

* 추가 발생한 문제(논의 사항)

### 화면 예시
---
