### PR TITLE
[refactor] 사용자의 member 정보를 전역(zustand)로 관리하도록 수정

### DIFF
--- a/fourtoon-cookie/App.tsx
+++ b/fourtoon-cookie/App.tsx
@@ -13,21 +13,28 @@ import IntroPage from './src/pages/IntroPage/IntroPage';
 import SettingPage from './src/pages/SettingPage/SettingPage';
 import { useCharacterListStore } from './src/store/characterList';
 import { useJWTStore } from './src/store/jwt';
+import { useMemberStore } from './src/store/member';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function App() {
 
+	const [ isLoaded, setIsLoaded ] = useState<boolean>(false);
+
 	const { jwt } = useJWTStore();
+	const { reloadMember } = useMemberStore();
 	const { updateCharacterList } = useCharacterListStore();
 
 	useEffect(() => {
-		if (! jwt) return;
+		if (jwt) {
+			reloadMember();
+			updateCharacterList();
+		}
 
-		updateCharacterList();
-	}, [jwt, updateCharacterList]);
+		setIsLoaded(true);
+	}, [jwt, reloadMember, updateCharacterList, isLoaded]);
 
-	if (! jwt) return null;
+	if (! isLoaded) return null;
 
 	return (
 		<NavigationContainer>

--- a/fourtoon-cookie/App.tsx
+++ b/fourtoon-cookie/App.tsx
@@ -22,8 +22,23 @@ export default function App() {
 	const [ isLoaded, setIsLoaded ] = useState<boolean>(false);
 
 	const { jwt } = useJWTStore();
-	const { reloadMember } = useMemberStore();
+	const { member, reloadMember, logoutMember } = useMemberStore();
 	const { updateCharacterList } = useCharacterListStore();
+
+	const navigationRef = useRef<NavigationContainerRef<RootStackParamList> | null>(null);
+
+	const navigateByMemberStatus = async () => {
+		if (! jwt) {
+			navigationRef.current?.navigate('IntroPage');
+			return;
+		}
+
+		if (! member){
+			navigationRef.current?.navigate('SignUpPage');
+		}
+
+		navigationRef.current?.navigate('DiaryTimelinePage');
+    }
 
 	useEffect(() => {
 		if (jwt) {
@@ -34,10 +49,13 @@ export default function App() {
 		setIsLoaded(true);
 	}, [jwt, reloadMember, updateCharacterList, isLoaded]);
 
+	useEffect(() => {
+		navigateByMemberStatus();
+	}, [member, jwt]);
 	if (! isLoaded) return null;
 
 	return (
-		<NavigationContainer>
+		<NavigationContainer ref={navigationRef}>
 			<ActionSheetProvider>
 				<Stack.Navigator initialRouteName="IntroPage" screenOptions={{ headerShown: false }}>
 					<Stack.Screen name="IntroPage" component={IntroPage} />

--- a/fourtoon-cookie/App.tsx
+++ b/fourtoon-cookie/App.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import React, { useEffect, useRef, useState } from 'react';
+import { NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { ActionSheetProvider } from "@expo/react-native-action-sheet";
 import { StyleSheet } from 'react-native';
@@ -52,6 +52,13 @@ export default function App() {
 	useEffect(() => {
 		navigateByMemberStatus();
 	}, [member, jwt]);
+
+	useEffect(() => {
+		if (member && ! jwt){
+			logoutMember();
+		}
+	}, [member, jwt]);
+
 	if (! isLoaded) return null;
 
 	return (

--- a/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
+++ b/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
@@ -13,27 +13,11 @@ const IntroPage = () => {
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
     const { jwt, setJWT } = useJWTStore();
-    const { member } = useMemberStore();
-
-    
-    const navigateByCheckingMemberExist = async () => {
-        if (member){
-            navigation.navigate('DiaryTimelinePage');
-            return;
-        }
-
-        if (jwt) {
-            navigation.navigate('SignUpPage');
-            return;
-        }
-    }
-
-    useEffect(() => {
-        navigateByCheckingMemberExist();
-    }, [jwt, member]);
+    const { reloadMember } = useMemberStore();
 
     const handleSignUpAndSignInSuccess = async (token: JWTToken) => {
-        setJWT(token);
+        await setJWT(token);
+        await reloadMember();
     }
 
     return (

--- a/fourtoon-cookie/src/pages/SettingPage/InfoLayout/InfoLayout.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/InfoLayout/InfoLayout.tsx
@@ -2,16 +2,12 @@ import { Image, Text, TouchableOpacity, View } from 'react-native';
 import * as S from "./InfoLayout.styled";
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { RootStackParamList } from '../../../constants/routing';
-import type { Member } from '../../../types/member';
 import { useSelectedCharacterStore } from '../../../store/selectedCharacter';
+import { useMemberStore } from '../../../store/member';
 
+const InfoLayout = () => {
 
-export interface InfoLayoutProps {
-    member: Member | null;
-}
-
-const InfoLayout = (props: InfoLayoutProps) => {
-    const { member, ...rest } = props;
+    const { member } = useMemberStore();
 
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
     const { selectedCharacter } = useSelectedCharacterStore();
@@ -24,7 +20,7 @@ const InfoLayout = (props: InfoLayoutProps) => {
         <View style={S.styles.profileContainer}>
             <Image source={{uri: selectedCharacter?.selectionThumbnailUrl}} style={S.styles.profileImage} />
             <Text style={S.styles.name}>{member?.name}</Text>
-            <Text style={S.styles.email}>{member?.email}</Text>
+            <Text style={S.styles.email}>{null}</Text>
             <TouchableOpacity style={S.styles.changeCharacterButton} onPress={handleCharacterChangeButtonPress}>
                 <Text style={S.styles.changeCharacterText}>캐릭터 변경</Text>
             </TouchableOpacity>

--- a/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
@@ -8,11 +8,11 @@ import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { RootStackParamList } from '../../../constants/routing';
 import handleError from '../../../error/errorhandler';
 import { APP_INFO_URL } from '../../../constants/appinfo';
-import { useJWTStore } from '../../../store/jwt';
+import { useMemberStore } from '../../../store/member';
 
 const MenuLayout = () => {
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
-    const { removeJWT } = useJWTStore();
+    const { logoutMember } = useMemberStore();
     const [ isModalVisible, setIsModalVisible ] = useState(false);
 
     const handleInquiry = () => {
@@ -25,7 +25,7 @@ const MenuLayout = () => {
     }
 
     const handleLogout = async () => {
-        removeJWT();
+        logoutMember();
         navigation.navigate('IntroPage');
     }
 

--- a/fourtoon-cookie/src/pages/SettingPage/MenuLayout/ResignModal/ResignModal.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/MenuLayout/ResignModal/ResignModal.tsx
@@ -1,10 +1,9 @@
 import ConfirmationModal from "../../../../components/common/Modal/ConfirmationModal/ConfirmationModal"
-import { deleteMember } from "../../../../apis/member";
 import { GlobalErrorInfoType } from "../../../../types/error";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { RootStackParamList } from "../../../../constants/routing";
 import handleError from "../../../../error/errorhandler";
-import { useJWTStore } from "../../../../store/jwt";
+import { useMemberStore } from "../../../../store/member";
 
 export interface ResignModalProps {
     visible: boolean;
@@ -16,12 +15,11 @@ const ResignModal = (props: ResignModalProps) => {
 
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
-    const { removeJWT } = useJWTStore();
+    const { resignMember } = useMemberStore();
 
     const handleResign = async () => {
         try {
-            await deleteMember();
-            removeJWT();
+            resignMember();
             navigation.navigate('IntroPage');
             onClose();
         } catch (error) {

--- a/fourtoon-cookie/src/pages/SettingPage/SettingPage.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/SettingPage.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useContext, useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
 import * as S from './SettingPage.styled';
 import type { Member } from '../../types/member';
-import { getMember } from '../../apis/member';
 import MenuLayout from './MenuLayout/MenuLayout';
 import { GlobalErrorInfoType } from '../../types/error';
 import MainPageLayout from '../../components/layout/MainPageLayout/MainPageLayout';
@@ -11,30 +10,11 @@ import handleError from '../../error/errorhandler';
 import { FOOTER_STATE } from '../../components/layout/MainPageLayout/Footer/Footer';
 
 const SettingPage = () => {
-	const [member, setMember] = useState<Member | null>(null);
-
-  	useEffect(() => {
-		const fetchMember = async () => {
-			try {
-				const memberData = await getMember();
-				setMember(memberData);
-			} catch (error) {
-				if (error instanceof Error) {
-                    handleError(
-						error,
-						GlobalErrorInfoType.ALERT
-					);
-                }
-			}
-		};
-	
-    	fetchMember();
-  	}, []);
 
 	return (
     	<MainPageLayout footerState={FOOTER_STATE.SETTING} >
 			<View style={S.styles.container}>
-				<InfoLayout member={member} />
+				<InfoLayout />
 				<MenuLayout />
 			</View>
     	</MainPageLayout>

--- a/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
@@ -35,7 +35,7 @@ const SignUpPage = () => {
 
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
-    const { jwt, removeJWT } = useJWTStore();
+    const { removeJWT } = useJWTStore();
     const { signupMember } = useMemberStore();
 
     const isNextButtonAvailabe: boolean = 
@@ -43,13 +43,6 @@ const SignUpPage = () => {
         || (signUpProgress == SignUpProgres.BIRTH && birth != null && ! birth.isAfter(LocalDate.now()))
         || (signUpProgress == SignUpProgres.GENDER && gender != null)
         || (signUpProgress == SignUpProgres.AGREEMENT && isAgreed);
-    
-    useEffect(() => {
-        if (! jwt) {
-            navigation.navigate('IntroPage');
-        }
-
-    }, [navigation]);
 
     const handleNameChange = (name: string) => {
         if (signUpProgress != SignUpProgres.NAME) return;
@@ -73,7 +66,6 @@ const SignUpPage = () => {
     const handleBackButtonPress = () => {
         if (signUpProgress == SignUpProgres.NAME) {
             removeJWT();
-            navigation.goBack();
             return;
         }
 

--- a/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
@@ -10,13 +10,13 @@ import BirthInputLayout from "./BirthInputLayout/BirthInputLayout";
 import GenderInputLayout from "./GenderInputLayout/GenderInputLayout";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { RootStackParamList } from "../../constants/routing";
-import { postMember } from "../../apis/member";
 import { LocalDate } from "@js-joda/core";
 import { GlobalErrorInfoType } from "../../types/error";
 import handleError from "../../error/errorhandler";
 
 import AgreementInputLayout from "./AgreementInputLayout/AgreementInputLayout";
 import { useJWTStore } from "../../store/jwt";
+import { useMemberStore } from "../../store/member";
 
 enum SignUpProgres {
     NAME = 1,
@@ -36,6 +36,7 @@ const SignUpPage = () => {
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
     const { jwt, removeJWT } = useJWTStore();
+    const { signupMember } = useMemberStore();
 
     const isNextButtonAvailabe: boolean = 
         (signUpProgress == SignUpProgres.NAME && name.length > 0)
@@ -88,7 +89,11 @@ const SignUpPage = () => {
             if (!gender || !isAgreed) return;
 
             try {
-                postMember(name, birth, gender);
+                signupMember({
+                    name,
+                    birth,
+                    gender,
+                });
                 navigation.navigate('DiaryTimelinePage');
             } catch (error) {
                 if (error instanceof Error) {

--- a/fourtoon-cookie/src/store/member.ts
+++ b/fourtoon-cookie/src/store/member.ts
@@ -1,0 +1,62 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { Member } from "../types/member";
+import { useJWTStore } from "./jwt";
+import { deleteMember, getMember } from "../apis/member";
+
+
+export interface MemberState {
+    member: Member | null;
+    reloadMember: () => void;
+    logoutMember: () => void;
+    resignMember: () => void;
+    updateMember: (member: Member) => void;
+}
+
+
+export const useMemberStore = create(
+    persist<MemberState>((set) => ({
+        member: null,
+
+        reloadMember: async () => {
+            try {
+                const member = await getMember();
+                set({ member });
+            } catch (e) {
+                set({ member: null });
+                useJWTStore.getState().removeJWT();
+            }
+        },
+
+        logoutMember: () => {
+            set({ member: null });
+            useJWTStore.getState().removeJWT();
+        },
+
+        resignMember: async () => {
+            await deleteMember();
+            set({ member: null });
+            useJWTStore.getState().removeJWT();
+        },
+
+        updateMember: async (member: Member) => {
+            //TODO 추후 API에 멤버 정보 수정 기능이 추가되면 구현
+        }
+    }), 
+    {
+        name: "member-storage",
+        storage: {
+            getItem: async (name) => {
+                const item = await AsyncStorage.getItem(name);
+                return item ? JSON.parse(item) : null;
+            },
+            setItem: async (name, value) => {
+                await AsyncStorage.setItem(name, JSON.stringify(value));
+            },
+            removeItem: async (name) => {
+                await AsyncStorage.removeItem(name);
+            },
+        }
+    }
+));

--- a/fourtoon-cookie/src/store/member.ts
+++ b/fourtoon-cookie/src/store/member.ts
@@ -3,11 +3,12 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { Member } from "../types/member";
 import { useJWTStore } from "./jwt";
-import { deleteMember, getMember } from "../apis/member";
+import { deleteMember, getMember, postMember } from "../apis/member";
 
 
 export interface MemberState {
     member: Member | null;
+    signupMember: (member: Member) => void;
     reloadMember: () => void;
     logoutMember: () => void;
     resignMember: () => void;
@@ -18,6 +19,11 @@ export interface MemberState {
 export const useMemberStore = create(
     persist<MemberState>((set) => ({
         member: null,
+
+        signupMember: async (member: Member) => {
+            await postMember(member.name, member.birth, member.gender);
+            set({ member });
+        },
 
         reloadMember: async () => {
             try {

--- a/fourtoon-cookie/src/store/member.ts
+++ b/fourtoon-cookie/src/store/member.ts
@@ -35,9 +35,9 @@ export const useMemberStore = create(
             }
         },
 
-        logoutMember: () => {
+        logoutMember: async () => {
             set({ member: null });
-            useJWTStore.getState().removeJWT();
+            await useJWTStore.getState().removeJWT();
         },
 
         resignMember: async () => {

--- a/fourtoon-cookie/src/store/member.ts
+++ b/fourtoon-cookie/src/store/member.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { persist, PersistOptions } from "zustand/middleware";
 import { Member } from "../types/member";
 import { useJWTStore } from "./jwt";
 import { deleteMember, getMember, postMember } from "../apis/member";
@@ -52,6 +52,7 @@ export const useMemberStore = create(
     }), 
     {
         name: "member-storage",
+        partialize: (state: MemberState) => ({ member: state.member }),
         storage: {
             getItem: async (name) => {
                 const item = await AsyncStorage.getItem(name);
@@ -64,5 +65,5 @@ export const useMemberStore = create(
                 await AsyncStorage.removeItem(name);
             },
         }
-    }
+    } as PersistOptions<MemberState>
 ));

--- a/fourtoon-cookie/src/types/member.ts
+++ b/fourtoon-cookie/src/types/member.ts
@@ -1,7 +1,8 @@
 import { LocalDate } from "@js-joda/core"
+import { Gender } from "./gender"
 
 export interface Member {
     name: string,
-    gender: string,
+    gender: Gender,
     birth: LocalDate
 };

--- a/fourtoon-cookie/src/types/member.ts
+++ b/fourtoon-cookie/src/types/member.ts
@@ -2,7 +2,6 @@ import { LocalDate } from "@js-joda/core"
 
 export interface Member {
     name: string,
-    email: string,
     gender: string,
     birth: LocalDate
 };


### PR DESCRIPTION
### Pull Request 타입
- [ ] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [x] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-336
---
* 구현 내용

- 사용자의 member 정보를 전역으로 관리하도록 하여, [GET] /member 요청을 1회만 진행하여도 사용자가 어플리케이션을 사용할 수 있도록 하였습니다.

* 추가 발생한 문제(논의 사항)

- Auth 로직(JWT)과 member 로직이 별도로 존재하여서 이를 통합적으로 관리할 방법을 고민해보는 것도 좋을 것 같습니다.