### PR TITLE
[refactor] diaryList를 전역 상태(zustand)로 관리하도록 리팩토링

### DIFF
--- a/fourtoon-cookie/src/apis/diary.ts
+++ b/fourtoon-cookie/src/apis/diary.ts
@@ -46,7 +46,7 @@ export const postDiary = async (characterId: number, date: LocalDate, content: s
 
     const response = await requestApi(`/diary`, API_METHOD_TYPE.POST, requestBody);
 
-    if (response.status != API_STATUS.CREATED) {
+    if (response.status != API_STATUS.SUCCESS && response.status != API_STATUS.CREATED) {
         throw new ApiError("일기를 저장하는 중 오류가 발생했습니다. 다시 시도해 주세요.", response.status);
     }
 

--- a/fourtoon-cookie/src/apis/diary.ts
+++ b/fourtoon-cookie/src/apis/diary.ts
@@ -1,5 +1,5 @@
 import type { Diary } from "../types/diary";
-import type { DiaryPatchFavoriteRequest, DiarySaveRequest, DiarySavedResponse, DiaryUpdateRequest } from "../types/dto/diary";
+import type { DiaryCreatedResponse, DiaryPatchFavoriteRequest, DiarySaveRequest, DiarySavedResponse, DiaryUpdateRequest } from "../types/dto/diary";
 import { requestApi } from "./api";
 import { LocalDate } from "@js-joda/core";
 import { ApiError } from "../error/ApiError";
@@ -36,7 +36,7 @@ export const getDiaries = async (pageNumber: number): Promise<Diary[]> => {
     }
 }
 
-export const postDiary = async (characterId: number, date: LocalDate, content: string) => {
+export const postDiary = async (characterId: number, date: LocalDate, content: string) : Promise<number> => {
 
     const requestBody: DiarySaveRequest = {
         characterId: characterId,
@@ -49,6 +49,10 @@ export const postDiary = async (characterId: number, date: LocalDate, content: s
     if (response.status != API_STATUS.CREATED) {
         throw new ApiError("일기를 저장하는 중 오류가 발생했습니다. 다시 시도해 주세요.", response.status);
     }
+
+    const responseData: DiaryCreatedResponse = await response.json();
+
+    return responseData.diaryId;
 }
 
 export const putDiary = async (characterId: number, diaryId: number, content: string) => {

--- a/fourtoon-cookie/src/apis/diary.ts
+++ b/fourtoon-cookie/src/apis/diary.ts
@@ -46,7 +46,7 @@ export const postDiary = async (characterId: number, date: LocalDate, content: s
 
     const response = await requestApi(`/diary`, API_METHOD_TYPE.POST, requestBody);
 
-    if (response.status != API_STATUS.SUCCESS && response.status != API_STATUS.CREATED) {
+    if (! (response.status == API_STATUS.SUCCESS || response.status == API_STATUS.CREATED)) {
         throw new ApiError("일기를 저장하는 중 오류가 발생했습니다. 다시 시도해 주세요.", response.status);
     }
 

--- a/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePage.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePage.tsx
@@ -96,7 +96,7 @@ const DiaryWritePage = ({ navigation, route }: DiaryWritePageProp) => {
         try {
             if (! isEdit) {
                 await postDiary(diary);
-            } else if (diary) {
+            } else if (currentDiaryId !== -1) {
                 await updateDiary(diary);
             } else {
                 handleError(

--- a/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePage.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePage.tsx
@@ -1,11 +1,10 @@
 import { KeyboardAvoidingView, Platform, SafeAreaView, View } from "react-native";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import Header from "./Header/Header";
 import TextInputLayout from "./TextInputLayout/TextInputLayout";
 
-import { postDiary, putDiary } from "../../apis/diary";
 import { RootStackParamList } from "../../constants/routing";
 
 import * as S from "./DiaryWritePage.styled";
@@ -19,6 +18,8 @@ import handleError from "../../error/errorhandler";
 import { ApiError } from "../../error/ApiError";
 import { API_STATUS } from "../../constants/api";
 import { useSelectedCharacterStore } from "../../store/selectedCharacter";
+import { useDiaryListStore } from "../../store/diaryList";
+import { Diary } from "../../types/diary";
 
 
 export type DiaryWritePageProp = NativeStackScreenProps<RootStackParamList, 'DiaryWritePage'>;
@@ -33,6 +34,9 @@ const DiaryWritePage = ({ navigation, route }: DiaryWritePageProp) => {
 
     const { selectedCharacter } = useSelectedCharacterStore();
 
+    const { postDiary, updateDiary } = useDiaryListStore();
+
+    const currentDiaryId = diary ? diary.diaryId : -1;
     const isNextButtonEnabled: boolean = content.length > 0;
     
     useEffect(() => {
@@ -80,11 +84,20 @@ const DiaryWritePage = ({ navigation, route }: DiaryWritePageProp) => {
 
         setIsWorking(true);
 
+        const diary: Diary = {
+            diaryId: currentDiaryId,
+            content: content,
+            isFavorite: false,
+            diaryDate: diaryDate,
+            paintingImageUrls: [],
+            characterId: selectedCharacter.id
+        }
+
         try {
             if (! isEdit) {
-                await postDiary(selectedCharacter?.id, diaryDate, content);
+                await postDiary(diary);
             } else if (diary) {
-                await putDiary(selectedCharacter?.id, diary.diaryId, content);
+                await updateDiary(diary);
             } else {
                 handleError(
                     new RuntimeError("잘못된 형식입니다."),

--- a/fourtoon-cookie/src/store/diaryList.ts
+++ b/fourtoon-cookie/src/store/diaryList.ts
@@ -53,7 +53,7 @@ export const useDiaryListStore = create<DiaryListState>(
 
         postDiary: async (diary: Diary) => {
             
-            await postDiary(diary.characterId, diary.diaryDate, diary.content);
+            await postDiary(diary.characterId, diary.diaryDate, diary.content); //TODO 생성된 일기 아이디를 받아야 함.
 
             const { diaryList } = get();
             await set({

--- a/fourtoon-cookie/src/store/diaryList.ts
+++ b/fourtoon-cookie/src/store/diaryList.ts
@@ -53,7 +53,9 @@ export const useDiaryListStore = create<DiaryListState>(
 
         postDiary: async (diary: Diary) => {
             
-            await postDiary(diary.characterId, diary.diaryDate, diary.content); //TODO 생성된 일기 아이디를 받아야 함.
+            const diaryId: number = await postDiary(diary.characterId, diary.diaryDate, diary.content); //TODO 생성된 일기 아이디를 받아야 함.
+
+            diary.diaryId = diaryId;
 
             const { diaryList } = get();
             await set({

--- a/fourtoon-cookie/src/store/diaryList.ts
+++ b/fourtoon-cookie/src/store/diaryList.ts
@@ -1,0 +1,96 @@
+import { create } from "zustand";
+import { Diary } from "../types/diary";
+import { deleteDiary, getDiaries, patchDiaryFavorite, postDiary, putDiary } from "../apis/diary";
+
+
+interface DiaryListState {
+    diaryList: Diary[];
+    page: number;
+    hasMore: boolean;
+
+    loadFirstPage: () => Promise<void>;
+    loadNextPage: () => Promise<void>;
+
+    getDiaryById: (diaryId: number) => Diary | undefined;
+    postDiary: (diary: Diary) => Promise<void>;
+    deleteDiaryById: (diaryId: number) => Promise<void>;
+    updateDiary: (diary: Diary) => Promise<void>;
+    toggleFavoriteDiary: (diaryId: number) => Promise<void>;
+}
+
+export const useDiaryListStore = create<DiaryListState>(
+    (set, get) => ({
+        diaryList: [],
+        page: -1,
+        hasMore: true,
+
+        loadFirstPage: async () => {
+            const result = await getDiaries(0);
+            set({
+                diaryList: result,
+                page: 0,
+                hasMore: result.length > 0,
+            });
+        },
+        
+        loadNextPage: async () => {
+            const { diaryList, page, hasMore } = get();
+
+            if (!hasMore) return;
+
+            const result = await getDiaries(page + 1);
+            set({
+                diaryList: [...diaryList, ...result],
+                page: page + 1,
+                hasMore: result.length > 0,
+            });
+        },
+
+        getDiaryById: (diaryId: number): Diary | undefined => {
+            const { diaryList } = get();
+            return diaryList.find(diary => diary.diaryId === diaryId);
+        },
+
+        postDiary: async (diary: Diary) => {
+            
+            await postDiary(diary.characterId, diary.diaryDate, diary.content);
+
+            const { diaryList } = get();
+            await set({
+                diaryList: [diary, ...diaryList],
+            });
+        },
+
+        deleteDiaryById: async (diaryId: number) => {
+            await deleteDiary(diaryId);
+
+            const { diaryList } = get();
+            await set({
+                diaryList: diaryList.filter(diary => diary.diaryId !== diaryId)
+            });
+        },
+
+        updateDiary: async (diary: Diary) => {
+            await putDiary(diary.characterId, diary.diaryId, diary.content);
+
+            const { diaryList } = get();
+            await set({
+                diaryList: diaryList.map(currentDiary => currentDiary.diaryId === diary.diaryId ? diary : currentDiary),
+            });
+        },
+
+        toggleFavoriteDiary: async (diaryId: number) => {
+            await patchDiaryFavorite(diaryId, !get().getDiaryById(diaryId)?.isFavorite);
+
+            const { diaryList } = get();
+            await set({
+                diaryList: diaryList.map(
+                    currentDiary => 
+                        currentDiary.diaryId === diaryId ? 
+                            { ...currentDiary, isFavorite: !currentDiary.isFavorite } : currentDiary
+                ),
+            });
+        },
+
+    })
+)

--- a/fourtoon-cookie/src/store/diaryList.ts
+++ b/fourtoon-cookie/src/store/diaryList.ts
@@ -53,7 +53,7 @@ export const useDiaryListStore = create<DiaryListState>(
 
         postDiary: async (diary: Diary) => {
             
-            const diaryId: number = await postDiary(diary.characterId, diary.diaryDate, diary.content); //TODO 생성된 일기 아이디를 받아야 함.
+            const diaryId: number = await postDiary(diary.characterId, diary.diaryDate, diary.content);
 
             diary.diaryId = diaryId;
 

--- a/fourtoon-cookie/src/store/diaryList.ts
+++ b/fourtoon-cookie/src/store/diaryList.ts
@@ -39,8 +39,10 @@ export const useDiaryListStore = create<DiaryListState>(
             if (!hasMore) return;
 
             const result = await getDiaries(page + 1);
+            const newDiaryList = [...diaryList, ...result];
+            newDiaryList.sort((a, b) => b.diaryDate.compareTo(a.diaryDate));
             set({
-                diaryList: [...diaryList, ...result],
+                diaryList: newDiaryList,
                 page: page + 1,
                 hasMore: result.length > 0,
             });
@@ -58,8 +60,11 @@ export const useDiaryListStore = create<DiaryListState>(
             diary.diaryId = diaryId;
 
             const { diaryList } = get();
+            
+            const newDiaryList = [diary, ...diaryList];
+            newDiaryList.sort((a, b) => b.diaryDate.compareTo(a.diaryDate));
             await set({
-                diaryList: [diary, ...diaryList],
+                diaryList: newDiaryList,
             });
         },
 

--- a/fourtoon-cookie/src/types/dto/diary.ts
+++ b/fourtoon-cookie/src/types/dto/diary.ts
@@ -23,3 +23,7 @@ export interface DiarySavedResponse {
     paintingImageUrls: string[],
     characterId: number
 }
+
+export interface DiaryCreatedResponse {
+    diaryId: number
+}


### PR DESCRIPTION
### Pull Request 타입
- [ ] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [x] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-337
---
* 구현 내용

기존에는 클라이언트와 서버 사이의 diary에 대한 트랜잭션이 관리가 쉽지 않았습니다.
따라서 이에 대한 트랜잭션을 편리하게 관리하기 위해 diaryList를 전역 상태로 지정하였습니다.


+ 애플 개발자 심사에서의 버그도 현 PR을 통해 해결될 것이라고 생각합니다. 일기를 생성하자마자 바로 상태에 적용하기에 트랜잭션적인 면에서 깔끔해졌습니다.



* 추가로 의논할 문제

- 추후 페이지네이션에 대한 더 깊은 논의가 필요합니다.