### PR TITLE
[fix] diaryContent, diaryContentPreviewLines로 인해 안 보이는 버그 수정

### DIFF
--- a/fourtoon-cookie/src/config/diary.ts
+++ b/fourtoon-cookie/src/config/diary.ts
@@ -1,2 +1,2 @@
 export const diaryContentPreviewWordCount = 30;
-export const diaryContentPreviewLines = 4;
+export const diaryContentPreviewLines = 34;

--- a/fourtoon-cookie/src/pages/DiaryWritePage/TextInputLayout/TextInputLayout.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/TextInputLayout/TextInputLayout.tsx
@@ -18,7 +18,7 @@ const TextInputLayout = (props: TextInputLayoutProps) => {
                 placeholderTextColor="#CCCCCC"
                 value={text}
                 multiline={true}
-                scrollEnabled={false}
+                scrollEnabled={true}
                 onChangeText={onTextChange}
             />
         </View>


### PR DESCRIPTION
# [fix] diaryContent, diaryContentPreviewLines 안보이는 버그 수정

### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-403
---
* 구현 내용
- DiaryWritePage에서 일기 작성 중 작성 하고있는  내용이 긴 경우 스크롤이 안되서 아래 내용이 안보이는 버그 수정
    - TextInputLayout.tsx
        `scrollEnabled` 속성 false 에서 **true**로 변경 → 스크롤이 가능하게 했음
        
- diaryContentPreviewLines
    - DiaryTimePage에서 일기 내용이 긴 경우 짤려서 4줄 만 보이는 버그 수정
    - /src/config/diary.ts
        - `diaryContentPreviewLines` 값 4에서 **34**로 변경 -
            - 최대 DiaryContent가 1000글자 이고, 현재 Content 한 줄당 30글자 이므로 30*34 > 1000 따라서 34로 변경
