### PR TITLE
[bug] 캐릭터 미선택 상태로 DiaryWritePage에 접근할 시 무한 Alert가 발생하는 버그 수정

### DIFF
--- a/fourtoon-cookie/src/components/error/BasicErrorBoundary/BasicErrorBoundary.tsx
+++ b/fourtoon-cookie/src/components/error/BasicErrorBoundary/BasicErrorBoundary.tsx
@@ -6,6 +6,9 @@ import { JwtError } from "../../../types/error/JwtError"
 import { ApiError } from "../../../types/error/ApiError"
 import { Alert } from "react-native"
 import { RuntimeError } from "../../../types/error/RuntimeError"
+import { SelectedCharacterNotExistError } from "../../../types/error/character/SelectedCharacterNotExistError"
+import { NavigationProp, useNavigation } from "@react-navigation/native"
+import { RootStackParamList } from "../../../types/routing"
 
 export interface BasicErrorBoundaryProps {
     handleErrorBeforeHandling?: (error: Error) => boolean,
@@ -17,6 +20,8 @@ const BasicErrorBoundary = (props: BasicErrorBoundaryProps) => {
     const { handleErrorBeforeHandling, handleErrorAfterHandling, children } = props;
 
     const [ effectHandler, setEffectHandler ] = useState<undefined | (() => void)>(undefined);
+
+    const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
     const { logout } = useAccountState();
 
@@ -53,6 +58,14 @@ const BasicErrorBoundary = (props: BasicErrorBoundaryProps) => {
                 Alert.alert("서버에서 문제가 발생하였습니다. 문제가 지속되면 관리자에게 알려주세요.", error.message);
                 return true;
             }
+        }
+
+        if (error instanceof SelectedCharacterNotExistError) {
+            setEffectHandler(() => {
+                Alert.alert("선택된 캐릭터가 존재하지 않습니다. 캐릭터 선택 화면으로 이동합니다.");
+                navigation.navigate("CharacterSelectPage");
+            });
+            return true;
         }
 
         if (error instanceof RuntimeError) {

--- a/fourtoon-cookie/src/components/error/BasicErrorBoundary/BasicErrorBoundary.tsx
+++ b/fourtoon-cookie/src/components/error/BasicErrorBoundary/BasicErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { ErrorBoundary, FallbackProps } from "react-error-boundary"
 import ErrorComponent from "../ErrorComponent/ErrorComponent"
-import { ReactNode } from "react"
+import { ReactNode, useEffect, useState } from "react"
 import { useAccountState } from "../../../hooks/account"
 import { JwtError } from "../../../types/error/JwtError"
 import { ApiError } from "../../../types/error/ApiError"
@@ -16,7 +16,16 @@ export interface BasicErrorBoundaryProps {
 const BasicErrorBoundary = (props: BasicErrorBoundaryProps) => {
     const { handleErrorBeforeHandling, handleErrorAfterHandling, children } = props;
 
+    const [ effectHandler, setEffectHandler ] = useState<undefined | (() => void)>(undefined);
+
     const { logout } = useAccountState();
+
+    useEffect(() => {
+        if (effectHandler) {
+            effectHandler();
+            setEffectHandler(undefined);
+        }
+    }, [effectHandler]);
 
     const handleError = (error: Error) => {
         if (handleErrorBeforeHandling && handleErrorBeforeHandling(error)) {

--- a/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePage.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePage.tsx
@@ -1,5 +1,5 @@
-import { Alert, SafeAreaView, View } from "react-native";
-import { useEffect, useState } from "react";
+import { SafeAreaView, View } from "react-native";
+import { useState } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import Header from "./Header/Header";
@@ -10,12 +10,9 @@ import { RootStackParamList } from "../../types/routing";
 import * as S from "./DiaryWritePage.styled";
 import { LocalDate } from "@js-joda/core";
 
-import { useSelectedCharacterStore } from "../../hooks/store/selectedCharacter";
 import WriteDoneButtonLayout from "./WriteDoneButtonLayout/WriteDoneButtonLayout";
-import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { useDiaryById } from "../../hooks/server/diary";
-import { useEffectWithErrorHandling, useFunctionWithErrorHandling } from "../../hooks/error";
-import { SelectedCharacterNotExistError } from "../../types/error/character/SelectedCharacterNotExistError";
+import { useFunctionWithErrorHandling } from "../../hooks/error";
 
 
 export type DiaryWritePageProp = NativeStackScreenProps<RootStackParamList, 'DiaryWritePage'>;
@@ -23,21 +20,12 @@ export type DiaryWritePageProp = NativeStackScreenProps<RootStackParamList, 'Dia
 const DiaryWritePage = ({ route }: DiaryWritePageProp) => {
     const { currentDiaryId, ...rest } = route.params || { currentDiaryId : undefined };
 
-    const navigation = useNavigation<NavigationProp<RootStackParamList>>();
     const { data: currentDiary } = useDiaryById(currentDiaryId);
-    const { selectedCharacter } = useSelectedCharacterStore();
     
     const [diaryDate, setDiaryDate] = useState<LocalDate>(currentDiary ? currentDiary.diaryDate : LocalDate.now());
     const [content, setContent] = useState<string>(currentDiary ? currentDiary.content : "");
 
     const { functionWithErrorHandling } = useFunctionWithErrorHandling();
-    
-    useEffectWithErrorHandling(() => {
-        if (! selectedCharacter) {
-            navigation.navigate('CharacterSelectPage');
-            throw new SelectedCharacterNotExistError('캐릭터가 선택되지 않았습니다. 캐릭터를 선택해주세요.');
-        }
-    }, [selectedCharacter]);
 
     const handleDiaryDateChange = functionWithErrorHandling((newDate: LocalDate) => {
         setDiaryDate(newDate);

--- a/fourtoon-cookie/src/pages/DiaryWritePage/Header/CharacterIconButton/CharacterIconButton.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/Header/CharacterIconButton/CharacterIconButton.tsx
@@ -1,4 +1,3 @@
-import { useContext } from "react";
 import { Image, TouchableOpacity } from "react-native";
 import * as S from "./CharacterIconButton.styled";
 import { useSelectedCharacterStore } from "../../../../hooks/store/selectedCharacter";
@@ -12,14 +11,10 @@ const CharacterIconButton = (props: CharacterIconButtonProps) => {
 
     const { selectedCharacter } = useSelectedCharacterStore();
 
-    if (! selectedCharacter){
-        return null;
-    }
-
     return (
         <TouchableOpacity onPress={onCharacterChoosePress} style={S.styles.container}>
             <Image 
-                source={{ uri: selectedCharacter.selectionThumbnailUrl }} 
+                source={{ uri: selectedCharacter?.selectionThumbnailUrl }} 
                 style={S.styles.image} 
             />
         </TouchableOpacity>

--- a/fourtoon-cookie/src/pages/DiaryWritePage/Header/Header.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/Header/Header.tsx
@@ -3,11 +3,8 @@ import DateInfo from "./DateInfo/DateInfo";
 import BackButton from "../../../components/common/BackButton/BackButton";
 
 import * as S from "./Header.styled";
-import CharacterItem from "../../../components/character/CharacterItem/CharacterItem";
-import { useContext } from "react";
 import { LocalDate } from "@js-joda/core";
 import CharacterIconButton from "./CharacterIconButton/CharacterIconButton";
-import { useSelectedCharacterStore } from "../../../hooks/store/selectedCharacter";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { RootStackParamList } from "../../../types/routing";
 import { useFunctionWithErrorHandling } from "../../../hooks/error";
@@ -21,8 +18,6 @@ export interface HeaderProps {
 const Header = (props: HeaderProps) => {
     const { date, isDateChangeable, onDateChange, ...rest } = props;
 
-    const { selectedCharacter } = useSelectedCharacterStore();
-
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
     const { functionWithErrorHandling } = useFunctionWithErrorHandling();
@@ -35,7 +30,7 @@ const Header = (props: HeaderProps) => {
         <View style={S.styles.header}>
             <BackButton style={S.styles.backButton} />
             <DateInfo date={date} isChangeable={isDateChangeable} onDateChange={onDateChange} />
-            {selectedCharacter && <CharacterIconButton onCharacterChoosePress={handleCharacterChoosePress} />}
+            <CharacterIconButton onCharacterChoosePress={handleCharacterChoosePress} />
         </View>
     );
 }

--- a/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout/WriteDoneButtonLayout.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout/WriteDoneButtonLayout.tsx
@@ -14,6 +14,7 @@ import { useCreateDiary, useUpdateDiary } from "../../../hooks/server/diary";
 import { useAccountState } from "../../../hooks/account";
 import buttonTrack from "../../../system/amplitude";
 import { useFunctionWithErrorHandling } from "../../../hooks/error";
+import { SelectedCharacterNotExistError } from "../../../types/error/character/SelectedCharacterNotExistError";
 
 export interface WriteDoneButtonLayout {
     diaryDate: LocalDate;
@@ -38,8 +39,6 @@ const WriteDoneButtonLayout = (props: WriteDoneButtonLayout) => {
 
     const isNextButtonEnabled = content.length > 0 && ! isWorking;
 
-    if (! selectedCharacter) return null;
-
     const handleWriteDoneButtonPress = functionWithErrorHandling(() => {
         if (accountState !== AccountStatus.LOGINED) {
             Alert.alert(
@@ -54,6 +53,10 @@ const WriteDoneButtonLayout = (props: WriteDoneButtonLayout) => {
             );
             navigation.navigate('IntroPage');
             return;
+        }
+
+        if (! selectedCharacter) {
+            throw new SelectedCharacterNotExistError("캐릭터를 선택해주세요.");
         }
 
         if (isWorking) return;


### PR DESCRIPTION
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### HOTFIX
---
* 구현 내용
- 기존의 로직: 캐릭터 미선택 상태로 DiaryWritePage에 접근할 시 무한 Alert가 발생하였습니다.
- 이는 selectedCharacter가 변하지 않음에 따라 계속 동일한 useEffect 훅 내의 로직이 동작하여서이기 때문이었습니다.
- 따라서 로직을 다음과 같이 수정하였습니다.
DiaryWritePage에서 Done버튼을 눌렀을 때 selectedCharacter가 null인 경우 error throw
BasicErrorBoundary에서 해당 에러 캐치 후 effectHandler에 다음 로직 주입
```typescript
Alert.alert(...);
navigation.navigate("CharacterSelectPage");
```
effectHandler를 활용해 useEffect에서 해당 로직 실행 후 effectHandler를 undefined로 변경

+ 위의 로직을 구현하면서 다음과 같이 effectHandler를 만들었습니다.

```typescript
const [effectHandler, setEffectHandler] = useState<undefined | (() => void)>(undefined);

useEffect(() => {
   if(effectHandler){
         effectHandler();
         setEffectHandler(undefined);
   }
}, [effectHandler]);
```
