### PR TITLE
[refactor] 각 Page에서 Provider를 활용해서 state를 한번에 관리하도록 리팩토링

### DIFF
--- a/fourtoon-cookie/src/pages/CharacterSelectPage/ArtworkList.tsx
+++ b/fourtoon-cookie/src/pages/CharacterSelectPage/ArtworkList.tsx
@@ -6,13 +6,10 @@ import type { Character, CharacterPaymentType } from '../../types/character';
 import { useCharacters } from '../../hooks/server/character';
 
 import { StyleSheet } from 'react-native';
+import { useCharacterSelectPageContext } from './CharacterSelectPageProvider';
 
-export interface ArtworkListProps {
-	paymentType: CharacterPaymentType
-}
-
-const ArtworkList = (props: ArtworkListProps) => {
-	const { paymentType, ...rest } = props;
+const ArtworkList = () => {
+	const { selectedPaymentType } = useCharacterSelectPageContext();
 
 	const { data: characterList } = useCharacters();
 
@@ -33,7 +30,7 @@ const ArtworkList = (props: ArtworkListProps) => {
 		};
 
 		const charactersGroupedByArtworkTitle = groupByArtworkTitle(
-			characterList?.filter(character => character.paymentType === paymentType)
+			characterList?.filter(character => character.paymentType === selectedPaymentType)
 		)
 	
 		return (
@@ -49,7 +46,7 @@ const ArtworkList = (props: ArtworkListProps) => {
 			/>
 		);
 
-	}, [paymentType, characterList]);
+	}, [selectedPaymentType, characterList]);
 }
 
 interface ArtworkItemProps {

--- a/fourtoon-cookie/src/pages/CharacterSelectPage/CharacterSelectPage.tsx
+++ b/fourtoon-cookie/src/pages/CharacterSelectPage/CharacterSelectPage.tsx
@@ -1,38 +1,31 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { CharacterPaymentType } from '../../types/character';
 
 import Header from './Header';
 import TabsLayout from './TabsLayout';
 import ArtworkList from './ArtworkList';
+import CharacterSelectPageProvider from './CharacterSelectPageProvider';
 
-import { useFunctionWithErrorHandling } from '../../hooks/error';
 
-
-const CharacterSelectPage = () => {
-    const [ selectedPaymentType, setSelectedPaymentType ] = useState<CharacterPaymentType>(CharacterPaymentType.FREE);
-
-    const { functionWithErrorHandling } = useFunctionWithErrorHandling();
-
-    const handleSelectedPaymentTypeChange = functionWithErrorHandling((characterPaymentType: CharacterPaymentType) => {
-        setSelectedPaymentType(characterPaymentType);
-    });
-
+const CharacterSelectPageContent = () => {
     return (
         <SafeAreaView style={styles.container}>
             <Header />
-            <TabsLayout
-                selectedPaymentType={selectedPaymentType}
-                onSelectedPaymentTypeChange={handleSelectedPaymentTypeChange}
-            />
+            <TabsLayout />
             <View style={styles.separator} />
-            <ArtworkList
-                paymentType={selectedPaymentType}
-            />
+            <ArtworkList />
         </SafeAreaView>
     );
 };
+
+const CharacterSelectPage = () => {
+    return (
+        <CharacterSelectPageProvider>
+            <CharacterSelectPageContent />
+        </CharacterSelectPageProvider>
+    );
+}
 
 export default CharacterSelectPage;
 

--- a/fourtoon-cookie/src/pages/CharacterSelectPage/CharacterSelectPageProvider.tsx
+++ b/fourtoon-cookie/src/pages/CharacterSelectPage/CharacterSelectPageProvider.tsx
@@ -1,0 +1,37 @@
+import { LocalDate } from "@js-joda/core";
+import { createContext, useContext, useState } from "react";
+import { CharacterPaymentType } from "../../types/character";
+
+export interface CharacterSelectPageContextType {
+    selectedPaymentType: CharacterPaymentType;
+    setSelectedPaymentType: (paymentType: CharacterPaymentType) => void;
+}
+
+const defaultCharacterSelectPageContextType: CharacterSelectPageContextType = {
+    selectedPaymentType: CharacterPaymentType.FREE,
+    setSelectedPaymentType: () => {},
+}
+
+const CharacterSelectPageContext = createContext<CharacterSelectPageContextType>(defaultCharacterSelectPageContextType);
+
+export interface CharacterSelectPageProviderProps {
+    children: React.ReactNode;
+}
+
+const CharacterSelectPageProvider = (props: CharacterSelectPageProviderProps) => {
+    const { children } = props;
+
+    const [ selectedPaymentType, setSelectedPaymentType ] = useState<CharacterPaymentType>(CharacterPaymentType.FREE);
+
+    return (
+        <CharacterSelectPageContext.Provider value={{selectedPaymentType, setSelectedPaymentType}}>
+            {children}
+        </CharacterSelectPageContext.Provider>
+    );
+}
+
+export default CharacterSelectPageProvider;
+
+export const useCharacterSelectPageContext = () => {
+    return useContext(CharacterSelectPageContext);
+}

--- a/fourtoon-cookie/src/pages/CharacterSelectPage/TabsLayout.tsx
+++ b/fourtoon-cookie/src/pages/CharacterSelectPage/TabsLayout.tsx
@@ -3,14 +3,10 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { CharacterPaymentType } from '../../types/character';
 
 import { useTranslationWithParentName } from '../../hooks/locale';
+import { useCharacterSelectPageContext } from './CharacterSelectPageProvider';
 
-export interface TabsLayoutProps {
-    selectedPaymentType: CharacterPaymentType;
-    onSelectedPaymentTypeChange: (characterPaymentType: CharacterPaymentType) => void;
-}
-
-const TabsLayout = (props: TabsLayoutProps) => {
-    const { selectedPaymentType, onSelectedPaymentTypeChange, ...rest } = props;
+const TabsLayout = () => {
+    const { selectedPaymentType, setSelectedPaymentType } = useCharacterSelectPageContext();
 
     const t = useTranslationWithParentName('pages.characterSelectPage.tabsLayout');
     
@@ -24,7 +20,7 @@ const TabsLayout = (props: TabsLayoutProps) => {
                     <Tab
                         isActive={selectedPaymentType === item.type}
                         label={item.label}
-                        onPress={() => onSelectedPaymentTypeChange(item.type)}
+                        onPress={() => setSelectedPaymentType(item.type)}
                     />
                 ))
             }

--- a/fourtoon-cookie/src/pages/DiaryWritePage/CharacterIconButton.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/CharacterIconButton.tsx
@@ -1,17 +1,23 @@
 import { Image, StyleSheet, TouchableOpacity } from "react-native";
 import { useSelectedCharacterStore } from "../../hooks/store/selectedCharacter";
+import { useFunctionWithErrorHandling } from "../../hooks/error";
+import { NavigationProp, useNavigation } from "@react-navigation/native";
+import { RootStackParamList } from "../../types/routing";
 
-export interface CharacterIconButtonProps {
-    onCharacterChoosePress: () => void;
-}
 
-const CharacterIconButton = (props: CharacterIconButtonProps) => {
-    const { onCharacterChoosePress, ...rest } = props;
-
+const CharacterIconButton = () => {
     const { selectedCharacter } = useSelectedCharacterStore();
 
+    const navigation = useNavigation<NavigationProp<RootStackParamList>>()
+
+    const { functionWithErrorHandling } = useFunctionWithErrorHandling();
+
+    const handleCharacterChoosePress = functionWithErrorHandling(() => {
+        navigation.navigate("CharacterSelectPage");
+    });
+
     return (
-        <TouchableOpacity onPress={onCharacterChoosePress} style={styles.container}>
+        <TouchableOpacity onPress={handleCharacterChoosePress} style={styles.container}>
             <Image 
                 source={{ uri: selectedCharacter?.selectionThumbnailUrl }} 
                 style={styles.image} 

--- a/fourtoon-cookie/src/pages/DiaryWritePage/DateInfo.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/DateInfo.tsx
@@ -5,23 +5,17 @@ import DOWN_ARROW from '../../../assets/icon/down-arrow.png';
 
 import { LocalDate } from '@js-joda/core';
 import { useFunctionWithErrorHandling } from '../../hooks/error';
+import { useDiaryWritePageContext } from './DiaryWritePageProvider';
 
-export interface DateInfoProps {
-    date: LocalDate;
-    isChangeable: boolean;
-    onDateChange: (date: LocalDate) => void;
-}
-
-const DateInfo = (props: DateInfoProps) => {
-    const { date, isChangeable, onDateChange, ...rest } = props;
-
-    const dateString: string = date.toString();
-
+const DateInfo = () => {
+    const { currentDiaryId, diaryDate, setDiaryDate } = useDiaryWritePageContext();
 
     const [isDatePickerVisible, setDatePickerVisible] = useState<boolean>(false);
 
     const { functionWithErrorHandling } = useFunctionWithErrorHandling();
 
+    const isChangeable: boolean = ! currentDiaryId;
+    const dateString: string = diaryDate.toString();
 
     const handleDatePress = functionWithErrorHandling(() => {
         if (! isChangeable) return;
@@ -35,7 +29,7 @@ const DateInfo = (props: DateInfoProps) => {
     const handleConfirm = functionWithErrorHandling((date: Date) => {
         if (date.getTime() > Date.now()) return;
         const localDate: LocalDate = LocalDate.of(date.getFullYear(), date.getMonth() + 1, date.getDate());
-        onDateChange(localDate);
+        setDiaryDate(localDate);
         setDatePickerVisible(false);
     })
 
@@ -49,7 +43,7 @@ const DateInfo = (props: DateInfoProps) => {
             <DateTimePickerModal 
                 isVisible={isDatePickerVisible}
                 mode="date"
-                date={new Date(date.year(), date.monthValue() - 1, date.dayOfMonth())}
+                date={new Date(diaryDate.year(), diaryDate.monthValue() - 1, diaryDate.dayOfMonth())}
                 onConfirm={handleConfirm}
                 onCancel={handleCancel}
                 style={styles.dateModal}

--- a/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePage.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePage.tsx
@@ -1,68 +1,44 @@
 import { SafeAreaView, StyleSheet, View } from "react-native";
-import { useState } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import TextInputLayout from "./TextInputLayout";
 
 import { RootStackParamList } from "../../types/routing";
 
-import { LocalDate } from "@js-joda/core";
-
 import WriteDoneButtonLayout from "./WriteDoneButtonLayout";
-import { useDiaryById } from "../../hooks/server/diary";
-import { useFunctionWithErrorHandling } from "../../hooks/error";
 import BackButton from "../../components/common/BackButton";
 import DateInfo from "./DateInfo";
 import CharacterIconButton from "./CharacterIconButton";
-import { NavigationProp, useNavigation } from "@react-navigation/native";
+import DiaryWritePageProvider from "./DiaryWritePageProvider";
 
+
+
+const DiaryWritePageContent = () => {
+    return (
+        <SafeAreaView style={styles.safeArea}>
+            <View style={styles.container}>
+                <View style={styles.header}>
+                    <BackButton style={styles.backButton}/>
+                    <DateInfo/>
+                    <CharacterIconButton/>
+                </View>
+                <TextInputLayout/>
+                <View style={styles.separator} />
+                <WriteDoneButtonLayout/>
+            </View>
+        </SafeAreaView>
+    );
+}
 
 export type DiaryWritePageProp = NativeStackScreenProps<RootStackParamList, 'DiaryWritePage'>;
 
 const DiaryWritePage = ({ route }: DiaryWritePageProp) => {
     const { currentDiaryId, ...rest } = route.params || { currentDiaryId : undefined };
 
-    const { data: currentDiary } = useDiaryById(currentDiaryId);
-    
-    const [diaryDate, setDiaryDate] = useState<LocalDate>(currentDiary ? currentDiary.diaryDate : LocalDate.now());
-    const [content, setContent] = useState<string>(currentDiary ? currentDiary.content : "");
-
-    const navigation = useNavigation<NavigationProp<RootStackParamList>>();
-
-    const { functionWithErrorHandling } = useFunctionWithErrorHandling();
-
-    const handleCharacterChoosePress = functionWithErrorHandling(() => {
-        navigation.navigate("CharacterSelectPage");
-    });
-
-    const handleDiaryDateChange = functionWithErrorHandling((newDate: LocalDate) => {
-        setDiaryDate(newDate);
-    })
-
-    const handleInputTextChange = functionWithErrorHandling((text: string) => {
-        setContent(text);
-    })
-
     return (
-        <SafeAreaView style={styles.safeArea}>
-            <View style={styles.container}>
-                <View style={styles.header}>
-                    <BackButton style={styles.backButton} />
-                    <DateInfo date={diaryDate} isChangeable={! currentDiaryId} onDateChange={handleDiaryDateChange} />
-                    <CharacterIconButton onCharacterChoosePress={handleCharacterChoosePress} />
-                </View>
-                <TextInputLayout
-                    text={content}
-                    onTextChange={handleInputTextChange}
-                />
-                <View style={styles.separator} />
-                <WriteDoneButtonLayout
-                    diaryDate={diaryDate}
-                    content={content}
-                    currentDiaryId={currentDiaryId}
-                />
-            </View>
-        </SafeAreaView>
+        <DiaryWritePageProvider currentDiaryId={currentDiaryId} >
+            <DiaryWritePageContent />
+        </DiaryWritePageProvider>
     );
 }
 

--- a/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePageProvider.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/DiaryWritePageProvider.tsx
@@ -1,0 +1,49 @@
+import { LocalDate } from "@js-joda/core";
+import { createContext, useContext, useState } from "react";
+import { useDiaryById } from "../../hooks/server/diary";
+
+export interface DiaryWritePageContextType {
+    currentDiaryId: number | undefined;
+    diaryDate: LocalDate;
+    content: string;
+
+    setDiaryDate: (diaryDate: LocalDate) => void;
+    setContent: (content: string) => void;
+}
+
+const defaultDiaryWritePageContext: DiaryWritePageContextType = {
+    currentDiaryId: undefined,
+    diaryDate: LocalDate.now(),
+    content: "",
+
+    setDiaryDate: () => {},
+    setContent: () => {},
+}
+
+const DiaryWritePageContext = createContext<DiaryWritePageContextType>(defaultDiaryWritePageContext);
+
+export interface DiaryWritePageProviderProps {
+    currentDiaryId: number | undefined;
+    children: React.ReactNode;
+}
+
+const DiaryWritePageProvider = (props: DiaryWritePageProviderProps) => {
+    const { currentDiaryId, children } = props;
+
+    const { data: currentDiary } = useDiaryById(currentDiaryId);
+
+    const [diaryDate, setDiaryDate] = useState<LocalDate>(currentDiary ? currentDiary.diaryDate : LocalDate.now());
+    const [content, setContent] = useState<string>(currentDiary ? currentDiary.content : "");
+
+    return (
+        <DiaryWritePageContext.Provider value={{currentDiaryId, diaryDate, content, setDiaryDate, setContent}}>
+            {children}
+        </DiaryWritePageContext.Provider>
+    );
+}
+
+export default DiaryWritePageProvider;
+
+export const useDiaryWritePageContext = () => {
+    return useContext(DiaryWritePageContext);
+}

--- a/fourtoon-cookie/src/pages/DiaryWritePage/TextInputLayout.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/TextInputLayout.tsx
@@ -1,14 +1,10 @@
 import { StyleSheet, TextInput, View } from "react-native";
 
 import { useTranslationWithParentName } from "../../hooks/locale";
+import { useDiaryWritePageContext } from "./DiaryWritePageProvider";
 
-export interface TextInputLayoutProps {
-    text: string,
-    onTextChange: (value: string) => void,
-}
-
-const TextInputLayout = (props: TextInputLayoutProps) => {
-    const { text, onTextChange, ...rest } = props;
+const TextInputLayout = () => {
+    const { content, setContent } = useDiaryWritePageContext();
 
     const t = useTranslationWithParentName("pages.diaryWritePage.textInputLayout");
     
@@ -18,10 +14,10 @@ const TextInputLayout = (props: TextInputLayoutProps) => {
                 style={styles.diaryInput}
                 placeholder={t("placeholder")}
                 placeholderTextColor="#CCCCCC"
-                value={text}
+                value={content}
                 multiline={true}
                 scrollEnabled={true}
-                onChangeText={onTextChange}
+                onChangeText={setContent}
             />
         </View>
     );

--- a/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout.tsx
@@ -15,15 +15,11 @@ import buttonTrack from "../../system/amplitude";
 import { useFunctionWithErrorHandling } from "../../hooks/error";
 import { useTranslationWithParentName } from "../../hooks/locale";
 import { SelectedCharacterNotExistError } from "../../types/error/character/SelectedCharacterNotExistError";
+import { useDiaryWritePageContext } from "./DiaryWritePageProvider";
 
-export interface WriteDoneButtonLayout {
-    diaryDate: LocalDate;
-    content: string;
-    currentDiaryId?: number;
-}
 
-const WriteDoneButtonLayout = (props: WriteDoneButtonLayout) => {
-    const { diaryDate, content, currentDiaryId, ...rest } = props;
+const WriteDoneButtonLayout = () => {
+    const { diaryDate, content, currentDiaryId } = useDiaryWritePageContext();
 
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 

--- a/fourtoon-cookie/src/pages/SignUpPage/AgreementInputLayout.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/AgreementInputLayout.tsx
@@ -5,22 +5,21 @@ import { useEffectWithErrorHandling, useFunctionWithErrorHandling } from '../../
 import { APP_PRIVACY_URL, APP_TERMS_AGREEMENT_URL } from '../../config/appinfo';
 import { useTranslationWithParentName } from '../../hooks/locale';
 import Container from './Container';
+import { useSignUpPageContext } from './SignUpPageProvider';
 
-export interface AgreementInputLayoutProps {
-    onAgreementChange: (isAgreed: boolean) => void;
-}
 
-const AgreementInputLayout = (props: AgreementInputLayoutProps) => {
-    const { onAgreementChange, ...rest } = props;
-    const [isTermsAndPrivacyAgreed, setIsTermsAndPrivacyAgreed] = useState(false);
-    const [isAgeOver14, setIsAgeOver14] = useState(false);
+const AgreementInputLayout = () => {
+    const { setIsAgreed } = useSignUpPageContext();
 
     const { functionWithErrorHandling } = useFunctionWithErrorHandling();
 
     const t = useTranslationWithParentName('pages.signUpPage.agreementInputLayout');
 
+    const [isTermsAndPrivacyAgreed, setIsTermsAndPrivacyAgreed] = useState(false);
+    const [isAgeOver14, setIsAgeOver14] = useState(false);
+
     useEffectWithErrorHandling(() => {
-        onAgreementChange(isTermsAndPrivacyAgreed && isAgeOver14);
+        setIsAgreed(isTermsAndPrivacyAgreed && isAgeOver14);
     }, [isTermsAndPrivacyAgreed, isAgeOver14]);
 
     const handleTermsPress = functionWithErrorHandling(() => {

--- a/fourtoon-cookie/src/pages/SignUpPage/BirthInputLayout.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/BirthInputLayout.tsx
@@ -4,14 +4,10 @@ import { LocalDate } from "@js-joda/core";
 import { useFunctionWithErrorHandling } from "../../hooks/error";
 import Container from "./Container";
 import { useTranslationWithParentName } from "../../hooks/locale";
+import { useSignUpPageContext } from "./SignUpPageProvider";
 
-export interface BirthInputLayoutProps {
-    birth: LocalDate;
-    onBirthChange: (birth: LocalDate) => void;
-}
-
-const BirthInputLayout = (props: BirthInputLayoutProps) => {
-    const { birth, onBirthChange, ...rest } = props;
+const BirthInputLayout = () => {
+    const { birth, setBirth } = useSignUpPageContext();
 
     const { functionWithErrorHandling } = useFunctionWithErrorHandling();
 
@@ -19,10 +15,10 @@ const BirthInputLayout = (props: BirthInputLayoutProps) => {
 
     const handleDateChange = functionWithErrorHandling((event: DateTimePickerEvent, date?: Date | undefined) => {
         if (! date) {
-            onBirthChange(LocalDate.now());
+            setBirth(LocalDate.now());
         } else {
             const localDate: LocalDate = LocalDate.of(date.getFullYear(), date.getMonth() + 1, date.getDate());
-            onBirthChange(localDate);
+            setBirth(localDate);
         }
     })
 

--- a/fourtoon-cookie/src/pages/SignUpPage/GenderInputLayout.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/GenderInputLayout.tsx
@@ -4,14 +4,10 @@ import MALE_ICON from "../../../assets/icon/man.png";
 import FEMALE_ICON from "../../../assets/icon/woman.png";
 import Container from "./Container";
 import { useTranslationWithParentName } from "../../hooks/locale";
+import { useSignUpPageContext } from "./SignUpPageProvider";
 
-export interface GenderInputLayoutProps {
-    gender: Gender | null;
-    onGenderChange: (gender: Gender) => void;
-}
-
-const GenderInputLayout = (props: GenderInputLayoutProps) => {
-    const { gender, onGenderChange, ...rest } = props;
+const GenderInputLayout = () => {
+    const { gender, setGender } = useSignUpPageContext();
 
     const t = useTranslationWithParentName('pages.signUpPage.genderInputLayout');
 
@@ -22,7 +18,7 @@ const GenderInputLayout = (props: GenderInputLayoutProps) => {
                     <GenderComponent
                         gender={genderItem}
                         isSelected={gender == genderItem}
-                        onPress={() => onGenderChange(genderItem)}
+                        onPress={() => setGender(genderItem)}
                     />
                 </View>
             )}

--- a/fourtoon-cookie/src/pages/SignUpPage/Header.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/Header.tsx
@@ -1,19 +1,33 @@
 import { StyleSheet, Text, View } from "react-native";
 import BackButton from "../../components/common/BackButton"
 import { useTranslationWithParentName } from "../../hooks/locale";
+import { useFunctionWithErrorHandling } from "../../hooks/error";
+import { SignUpProgres, useSignUpPageContext } from "./SignUpPageProvider";
+import { useAccountState } from "../../hooks/account";
 
-export interface HeaderProps {
-    onBackButtonPress: () => void
-}
 
-const Header = (props: HeaderProps) => {
-    const { onBackButtonPress, ...rest } = props;
+const Header = () => {
+    const { signUpProgress, setSignUpProgress } = useSignUpPageContext();
+
+    const { logout } = useAccountState();
 
     const loginT = useTranslationWithParentName('login');
 
+    const { functionWithErrorHandling } = useFunctionWithErrorHandling();
+
+
+    const handleBackButtonPress = functionWithErrorHandling(() => {
+      if (signUpProgress == SignUpProgres.NAME) {
+          logout();
+          return;
+      }
+
+      setSignUpProgress(signUpProgress - 1);
+  })
+
     return (
         <View style={styles.header}>
-            <BackButton onPress={onBackButtonPress} style={styles.backButton} />
+            <BackButton onPress={handleBackButtonPress} style={styles.backButton} />
             <Text style={styles.headerText}>{loginT("signUp")}</Text>
         </View>
     );

--- a/fourtoon-cookie/src/pages/SignUpPage/NameInputLayout.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/NameInputLayout.tsx
@@ -1,14 +1,10 @@
 import { StyleSheet, TextInput } from "react-native";
 import { useTranslationWithParentName } from "../../hooks/locale";
 import Container from "./Container";
+import { useSignUpPageContext } from "./SignUpPageProvider";
 
-export interface NameInputLayoutProps {
-    name: string;
-    onNameChange: (name: string) => void;
-}
-
-const NameInputLayout = (props: NameInputLayoutProps) => {
-    const { name, onNameChange, ...rest } = props;
+const NameInputLayout = () => {
+    const { name, setName } = useSignUpPageContext();
 
     const t = useTranslationWithParentName('pages.signUpPage.nameInputLayout');
 
@@ -19,7 +15,7 @@ const NameInputLayout = (props: NameInputLayoutProps) => {
                 placeholder={t("placeholder")}
                 placeholderTextColor="#CCCCCC"
                 value={name}
-                onChangeText={onNameChange}
+                onChangeText={setName}
             />
         </Container>
     )

--- a/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
@@ -15,67 +15,23 @@ import AgreementInputLayout from "./AgreementInputLayout";
 import { useAccountState } from "../../hooks/account";
 import { useFunctionWithErrorHandling } from "../../hooks/error";
 import { useTranslationWithParentName } from "../../hooks/locale";
+import SignUpPageProvider, { SignUpProgres, useSignUpPageContext } from "./SignUpPageProvider";
 
-enum SignUpProgres {
-    NAME = 1,
-    BIRTH = 2,
-    GENDER = 3,
-    AGREEMENT = 4
-}
 
-const SignUpPage = () => {
-    const [name, setName] = useState<string>('');
-    const [birth, setBirth] = useState<LocalDate>(LocalDate.now());
-    const [gender, setGender] = useState<Gender | null>(null);
-    const [isAgreed, setIsAgreed] = useState<boolean>(false);
+const SignUpPageContent = () => {
+    const { name, birth, gender, isAgreed, signUpProgress, setSignUpProgress, isNextAvailabe } = useSignUpPageContext();
 
-    const [signUpProgress, setSignUpProgress] = useState<SignUpProgres>(SignUpProgres.NAME);
+    const { signup } = useAccountState();
 
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
-    const { logout, signup } = useAccountState();
-
     const { functionWithErrorHandling } = useFunctionWithErrorHandling();
 
-    const t = useTranslationWithParentName('pages.signUpPage');
     const commonT = useTranslationWithParentName('common');
 
-    const isNextButtonAvailabe: boolean = 
-        (signUpProgress == SignUpProgres.NAME && name.length > 0)
-        || (signUpProgress == SignUpProgres.BIRTH && birth != null && ! birth.isAfter(LocalDate.now()))
-        || (signUpProgress == SignUpProgres.GENDER && gender != null)
-        || (signUpProgress == SignUpProgres.AGREEMENT && isAgreed);
-
-    const handleNameChange = functionWithErrorHandling((name: string) => {
-        if (signUpProgress != SignUpProgres.NAME) return;
-        setName(name);
-    });
-
-    const handleBirthChange = functionWithErrorHandling((birth: LocalDate) => {
-        if (signUpProgress != SignUpProgres.BIRTH) return;
-        setBirth(birth);
-    });
-
-    const handleGenderChange = functionWithErrorHandling((gender: Gender) => {
-        if (signUpProgress != SignUpProgres.GENDER) return;
-        setGender(gender);
-    });
-
-    const handleAgreementChange = functionWithErrorHandling((isAgreed: boolean) => {
-        setIsAgreed(isAgreed);
-    });
-
-    const handleBackButtonPress = functionWithErrorHandling(() => {
-        if (signUpProgress == SignUpProgres.NAME) {
-            logout();
-            return;
-        }
-
-        setSignUpProgress(signUpProgress - 1);
-    })
 
     const handleNextButtonClick = functionWithErrorHandling(() => {
-        if (!isNextButtonAvailabe) return;
+        if (!isNextAvailabe) return;
 
         if (signUpProgress < SignUpProgres.AGREEMENT) {
             setSignUpProgress(signUpProgress + 1);
@@ -91,29 +47,15 @@ const SignUpPage = () => {
         }
     });
 
+    
     return (
         <SafeAreaView style={styles.safeArea}>
             <View style={styles.container}>
-                <Header onBackButtonPress={handleBackButtonPress}/>
-                {signUpProgress == SignUpProgres.NAME && 
-                <NameInputLayout 
-                    name={name} 
-                    onNameChange={handleNameChange} 
-                />}
-                {signUpProgress == SignUpProgres.BIRTH && 
-                <BirthInputLayout 
-                    birth={birth} 
-                    onBirthChange={handleBirthChange} 
-                />}
-                {signUpProgress == SignUpProgres.GENDER && 
-                <GenderInputLayout
-                    gender={gender} 
-                    onGenderChange={handleGenderChange} 
-                />}
-                {signUpProgress == SignUpProgres.AGREEMENT && 
-                <AgreementInputLayout 
-                    onAgreementChange={handleAgreementChange} 
-                />}
+                <Header/>
+                {signUpProgress == SignUpProgres.NAME && <NameInputLayout/>}
+                {signUpProgress == SignUpProgres.BIRTH && <BirthInputLayout />}
+                {signUpProgress == SignUpProgres.GENDER && <GenderInputLayout/>}
+                {signUpProgress == SignUpProgres.AGREEMENT && <AgreementInputLayout />}
                 <KeyboardAvoidingView 
                     style={styles.bottomContainer} 
                     enabled={true}
@@ -132,7 +74,7 @@ const SignUpPage = () => {
                         onPress={handleNextButtonClick}
                         style={{
                             ...styles.nextButton, 
-                            backgroundColor: isNextButtonAvailabe ? '#FFC426' : '#DDDDDD'
+                            backgroundColor: isNextAvailabe ? '#FFC426' : '#DDDDDD'
                         }}
                         textStyle={styles.nextButtonText}
                     />
@@ -141,6 +83,14 @@ const SignUpPage = () => {
         </SafeAreaView>
     );
 };
+
+const SignUpPage = () => {
+    return (
+        <SignUpPageProvider>
+            <SignUpPageContent/>
+        </SignUpPageProvider>
+    );
+}
 
 export default SignUpPage;
 

--- a/fourtoon-cookie/src/pages/SignUpPage/SignUpPageProvider.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/SignUpPageProvider.tsx
@@ -1,0 +1,76 @@
+import { LocalDate } from "@js-joda/core";
+import { createContext, useContext, useState } from "react";
+import { Gender } from "../../types/gender";
+
+export enum SignUpProgres {
+    NAME = 1,
+    BIRTH = 2,
+    GENDER = 3,
+    AGREEMENT = 4
+}
+
+export interface SignUpPageContextType {
+    name: string,
+    birth: LocalDate,
+    gender: Gender | null,
+    isAgreed: boolean,
+    signUpProgress: SignUpProgres,
+    isNextAvailabe: boolean,
+
+    setName: (name: string) => void,
+    setBirth: (birth: LocalDate) => void,
+    setGender: (gender: Gender) => void,
+    setIsAgreed: (isAgreed: boolean) => void,
+    setSignUpProgress: (progress: SignUpProgres) => void,
+}
+
+const defaultSignUpPageContext: SignUpPageContextType = {
+    name: '',
+    birth: LocalDate.now(),
+    gender: null,
+    isAgreed: false,
+    signUpProgress: SignUpProgres.NAME,
+    isNextAvailabe: false,
+
+    setName: () => {},
+    setBirth: () => {},
+    setGender: () => {},
+    setIsAgreed: () => {},
+    setSignUpProgress: () => {},
+}
+
+const SignUpPageContext = createContext<SignUpPageContextType>(defaultSignUpPageContext);
+
+export interface SignUpPageProviderProps {
+    children: React.ReactNode;
+}
+
+const SignUpPageProvider = (props: SignUpPageProviderProps) => {
+    const { children } = props;
+
+    const [name, setName] = useState<string>('');
+    const [birth, setBirth] = useState<LocalDate>(LocalDate.now());
+    const [gender, setGender] = useState<Gender | null>(null);
+    const [isAgreed, setIsAgreed] = useState<boolean>(false);
+
+    const [signUpProgress, setSignUpProgress] = useState<SignUpProgres>(SignUpProgres.NAME);
+
+    const isNextAvailabe: boolean = 
+        (signUpProgress == SignUpProgres.NAME && name.length > 0)
+        || (signUpProgress == SignUpProgres.BIRTH && birth != null && ! birth.isAfter(LocalDate.now()))
+        || (signUpProgress == SignUpProgres.GENDER && gender != null)
+        || (signUpProgress == SignUpProgres.AGREEMENT && isAgreed);
+
+
+    return (
+        <SignUpPageContext.Provider value={{name, birth, gender, isAgreed, signUpProgress, isNextAvailabe, setName, setBirth, setGender, setIsAgreed, setSignUpProgress}}>
+            {children}
+        </SignUpPageContext.Provider>
+    );
+}
+
+export default SignUpPageProvider;
+
+export const useSignUpPageContext = () => {
+    return useContext(SignUpPageContext);
+}


### PR DESCRIPTION
### Pull Request 타입
- [ ] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [x] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-432
---
* 구현 내용

1. 각 페이지별로 복잡하고 많은 State가 정의되어 넘기는 무의미한 Props가 많아지고, 불필요한 handler가 많아짐
2. 이에 따라 각 페이지의 전체적인 상태를 Provider가 제공하는 Context로 관리하도록 함으로써 페이별로 필요한 State를 바로 불러올 수 있도록 설정
3. Provider가 요구되는 페이지는 SignUpPage, DiaryWritePage, CharacterSelectPage뿐이어서 이에 대해서만 작업 진행함.
(단, 각 컴포넌트 "내"에서만 활용되는 state를 무조건적으로 Provider로 빼지는 않음)

* 추가 발생한 문제(논의 사항)
- 추후에는 hook callin 순서를 컨벤션으로 정하면 좋을 듯 함.