### PR TITLE
[refactor] 사용되지 않는 패키지 의존성 삭제

### DIFF
--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -28,7 +28,6 @@
         "expo-status-bar": "~1.12.1",
         "expo-updates": "~0.25.25",
         "i18next": "^23.16.0",
-        "lodash": "^4.17.21",
         "react": "18.2.0",
         "react-error-boundary": "^4.0.13",
         "react-i18next": "^15.0.3",

--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -32,7 +32,6 @@
         "react-native-get-random-values": "^1.11.0",
         "react-native-modal": "^13.0.1",
         "react-native-modal-datetime-picker": "^17.1.0",
-        "react-native-reanimated": "3.10.1",
         "react-native-safe-area-context": "4.10.5",
         "react-native-screens": "3.31.1",
         "react-native-share": "^11.0.3",
@@ -1495,6 +1494,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.7.tgz",
       "integrity": "sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
@@ -1575,6 +1575,7 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz",
       "integrity": "sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
@@ -1834,6 +1835,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz",
       "integrity": "sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
       },
@@ -13007,26 +13009,6 @@
       "peerDependencies": {
         "@react-native-community/datetimepicker": ">=6.7.0",
         "react-native": ">=0.65.0"
-      }
-    },
-    "node_modules/react-native-reanimated": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.10.1.tgz",
-      "integrity": "sha512-sfxg6vYphrDc/g4jf/7iJ7NRi+26z2+BszPmvmk0Vnrz6FL7HYljJqTf531F1x6tFmsf+FEAmuCtTUIXFLVo9w==",
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -35,7 +35,6 @@
         "react-native-safe-area-context": "4.10.5",
         "react-native-screens": "3.31.1",
         "react-native-share": "^11.0.3",
-        "react-native-url-polyfill": "^2.0.0",
         "react-navigation": "^5.0.0",
         "react-query": "^3.39.3",
         "uuid": "^10.0.0",
@@ -13040,17 +13039,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/react-native-url-polyfill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
-      "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
-      "dependencies": {
-        "whatwg-url-without-unicode": "8.0.0-3"
-      },
-      "peerDependencies": {
-        "react-native": "*"
       }
     },
     "node_modules/react-native/node_modules/@react-native/normalize-colors": {

--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -20,7 +20,6 @@
         "@sentry/react-native": "^5.33.1",
         "@supabase/supabase-js": "^2.44.4",
         "expo": "^51.0.34",
-        "expo-apple-authentication": "^6.4.2",
         "expo-dev-client": "~4.0.27",
         "expo-localization": "^15.0.3",
         "expo-media-library": "~16.0.5",
@@ -8366,14 +8365,6 @@
       },
       "bin": {
         "expo": "bin/cli"
-      }
-    },
-    "node_modules/expo-apple-authentication": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-6.4.2.tgz",
-      "integrity": "sha512-X4u1n3Ql1hOpztXHbKNq4I1l4+Ff82gC6RmEeW43Eht7VE6E8PrQBpYKw+JJv8osrCJt7R5O1PZwed6WLN5oig==",
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "node_modules/expo-asset": {

--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -24,7 +24,6 @@
         "expo-dev-client": "~4.0.27",
         "expo-localization": "^15.0.3",
         "expo-media-library": "~16.0.5",
-        "expo-status-bar": "~1.12.1",
         "expo-updates": "~0.25.25",
         "i18next": "^23.16.0",
         "react": "18.2.0",
@@ -8664,11 +8663,6 @@
       "dependencies": {
         "invariant": "^2.2.4"
       }
-    },
-    "node_modules/expo-status-bar": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.12.1.tgz",
-      "integrity": "sha512-/t3xdbS8KB0prj5KG5w7z+wZPFlPtkgs95BsmrP/E7Q0xHXTcDcQ6Cu2FkFuRM+PKTb17cJDnLkawyS5vDLxMA=="
     },
     "node_modules/expo-structured-headers": {
       "version": "3.8.0",

--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -30,7 +30,6 @@
         "react-i18next": "^15.0.3",
         "react-native": "0.74.5",
         "react-native-get-random-values": "^1.11.0",
-        "react-native-modal": "^13.0.1",
         "react-native-modal-datetime-picker": "^17.1.0",
         "react-native-safe-area-context": "4.10.5",
         "react-native-screens": "3.31.1",
@@ -12966,14 +12965,6 @@
         }
       }
     },
-    "node_modules/react-native-animatable": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.3.3.tgz",
-      "integrity": "sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      }
-    },
     "node_modules/react-native-get-random-values": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
@@ -12983,19 +12974,6 @@
       },
       "peerDependencies": {
         "react-native": ">=0.56"
-      }
-    },
-    "node_modules/react-native-modal": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-13.0.1.tgz",
-      "integrity": "sha512-UB+mjmUtf+miaG/sDhOikRfBOv0gJdBU2ZE1HtFWp6UixW9jCk/bhGdHUgmZljbPpp0RaO/6YiMmQSSK3kkMaw==",
-      "dependencies": {
-        "prop-types": "^15.6.2",
-        "react-native-animatable": "1.3.3"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": ">=0.65.0"
       }
     },
     "node_modules/react-native-modal-datetime-picker": {

--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -23,7 +23,6 @@
         "expo-apple-authentication": "^6.4.2",
         "expo-dev-client": "~4.0.27",
         "expo-localization": "^15.0.3",
-        "expo-location": "~17.0.1",
         "expo-media-library": "~16.0.5",
         "expo-status-bar": "~1.12.1",
         "expo-updates": "~0.25.25",
@@ -8519,14 +8518,6 @@
       "dependencies": {
         "rtl-detect": "^1.0.2"
       },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-location": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-17.0.1.tgz",
-      "integrity": "sha512-m+OzotzlAXO3ZZ1uqW5GC25nXW868zN+ROyBA1V4VF6jGay1ZEs4URPglCVUDzZby2F5wt24cMzqDKw2IX6nRw==",
       "peerDependencies": {
         "expo": "*"
       }

--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -32,7 +32,6 @@
         "react-native-get-random-values": "^1.11.0",
         "react-native-modal": "^13.0.1",
         "react-native-modal-datetime-picker": "^17.1.0",
-        "react-native-popup-menu": "^0.16.1",
         "react-native-reanimated": "3.10.1",
         "react-native-safe-area-context": "4.10.5",
         "react-native-screens": "3.31.1",
@@ -13009,11 +13008,6 @@
         "@react-native-community/datetimepicker": ">=6.7.0",
         "react-native": ">=0.65.0"
       }
-    },
-    "node_modules/react-native-popup-menu": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/react-native-popup-menu/-/react-native-popup-menu-0.16.1.tgz",
-      "integrity": "sha512-xRS7mRh0exwu7Iw8PPVHdM11d13A/KzYjy0/fZx3zVtxISxPkNaDGayau6oa7HqO3Nj0oS9ulFCYjcQfG6vahA=="
     },
     "node_modules/react-native-reanimated": {
       "version": "3.10.1",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -34,7 +34,6 @@
     "react-native-get-random-values": "^1.11.0",
     "react-native-modal": "^13.0.1",
     "react-native-modal-datetime-picker": "^17.1.0",
-    "react-native-popup-menu": "^0.16.1",
     "react-native-reanimated": "3.10.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -22,7 +22,6 @@
     "@sentry/react-native": "^5.33.1",
     "@supabase/supabase-js": "^2.44.4",
     "expo": "^51.0.34",
-    "expo-apple-authentication": "^6.4.2",
     "expo-dev-client": "~4.0.27",
     "expo-localization": "^15.0.3",
     "expo-media-library": "~16.0.5",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -25,7 +25,6 @@
     "expo-apple-authentication": "^6.4.2",
     "expo-dev-client": "~4.0.27",
     "expo-localization": "^15.0.3",
-    "expo-location": "~17.0.1",
     "expo-media-library": "~16.0.5",
     "expo-status-bar": "~1.12.1",
     "expo-updates": "~0.25.25",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -32,7 +32,6 @@
     "react-i18next": "^15.0.3",
     "react-native": "0.74.5",
     "react-native-get-random-values": "^1.11.0",
-    "react-native-modal": "^13.0.1",
     "react-native-modal-datetime-picker": "^17.1.0",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -26,7 +26,6 @@
     "expo-dev-client": "~4.0.27",
     "expo-localization": "^15.0.3",
     "expo-media-library": "~16.0.5",
-    "expo-status-bar": "~1.12.1",
     "expo-updates": "~0.25.25",
     "i18next": "^23.16.0",
     "react": "18.2.0",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -30,7 +30,6 @@
     "expo-status-bar": "~1.12.1",
     "expo-updates": "~0.25.25",
     "i18next": "^23.16.0",
-    "lodash": "^4.17.21",
     "react": "18.2.0",
     "react-error-boundary": "^4.0.13",
     "react-i18next": "^15.0.3",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -37,7 +37,6 @@
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
     "react-native-share": "^11.0.3",
-    "react-native-url-polyfill": "^2.0.0",
     "react-navigation": "^5.0.0",
     "react-query": "^3.39.3",
     "uuid": "^10.0.0",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -34,7 +34,6 @@
     "react-native-get-random-values": "^1.11.0",
     "react-native-modal": "^13.0.1",
     "react-native-modal-datetime-picker": "^17.1.0",
-    "react-native-reanimated": "3.10.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
     "react-native-share": "^11.0.3",


### PR DESCRIPTION
### Pull Request 타입
- [ ] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [x] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-435
---
* 구현 내용

코드에서 사용(import)되지 않고, 다른 패키지와의 의존성이 존재하지 않는 다음 패키지를 전부 삭제하였습니다.
```
expo-apple-authentication
expo-location
expo-status-bar
lodash
react-native-popup-menu
react-native-reanimated
react-native-url-polyfill
react-native-modal
```

* 추가 발생한 문제(논의 사항)

**현재 동작 테스트 진행해보아야 함**


추후에는 패키지 관리를 철저하게 할 필요성이 있어보입니다.
