### PR TITLE
[bug] 에러 핸들링 관련 버그 수정 & 변수 callin 실수 해결

### DIFF
--- a/fourtoon-cookie/src/components/error/BasicErrorBoundary.tsx
+++ b/fourtoon-cookie/src/components/error/BasicErrorBoundary.tsx
@@ -47,17 +47,17 @@ const BasicErrorBoundary = (props: BasicErrorBoundaryProps) => {
         if (error instanceof ApiError) {
             const status = error.getStatus();
             if (status === null) {
-                showErrorToast(t("default"), error.message);
+                setEffectHandler(() => showErrorToast(t("default"), error.message));
                 return true;
             }
 
             if (400 <= status && status <= 499) {
-                showErrorToast(t("user"), error.message);
+                setEffectHandler(() => showErrorToast(t("user"), error.message));
                 return true;
             }
 
             if (500 <= status && status <= 599) {
-                showErrorToast(t("server"), error.message);
+                setEffectHandler(() => showErrorToast(t("server"), error.message));
                 return true;
             }
         }

--- a/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
@@ -28,6 +28,7 @@ const SignUpPageContent = () => {
 
     const { functionWithErrorHandling } = useFunctionWithErrorHandling();
 
+    const loginT = useTranslationWithParentName('login');
     const commonT = useTranslationWithParentName('common');
 
 
@@ -45,7 +46,7 @@ const SignUpPageContent = () => {
                 gender,
             });
 
-            showSuccessToast(t('signupSuccess'));
+            showSuccessToast(loginT('signupSuccess'));
             navigation.navigate('DiaryTimelinePage');
         }
     });


### PR DESCRIPTION
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### HOTFIX
---
* 구현 내용

1. ErrorBoundary에서 showToast를 바로 진행하는 것이 아닌 effectHandler에 등록하는 형태로 로직을 수정함으로써 resetErrorBoundary가 된 이후 Toast를 표시할 수 있도록 로직을 수정함
2. useQueryWithErrorHandling이나 useInfiniteQueryWithErrorHandling은 상태를 불러오는 것이기에 기본적으로 코드에 계속 남아있음. 이에 따라 만약 해당 부분에서 오류가 발생할 경우 (오류 발생) -> (에러 바운더리 catch) -> (에러 바운더리 reset) 과정이 무한으로 반복됨.
따라서 두 훅에 cooldownSet을 등록하고 이에 대한 로직을 구현함.
오류가 발생하면 한번 오류를 던지고, 10초 동안은 동일한 오류를 던지지 않도록 로직을 구성함
3. SignUpPage에서 존재하지 않는 변수를 callin하는 실수를 해결함