### PR TITLE
[bug] 일기 생성 버튼 관련 버그 수정

### DIFF
--- a/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout.tsx
@@ -26,8 +26,8 @@ const WriteDoneButtonLayout = () => {
 
     const [isWorking, setIsWorking] = useState<boolean>(false);
 
-    const { mutate: createDiary, isLoading: isCreateMutateLoading, isSuccess: isCreateMutationSuccess } = useCreateDiary();
-    const { mutate: updateDiary, isLoading: isUpdateMutateLoading, isSuccess: isUpdateMutationSuccess } = useUpdateDiary();
+    const { mutate: createDiary, isSuccess: isCreateMutationSuccess } = useCreateDiary();
+    const { mutate: updateDiary, isSuccess: isUpdateMutationSuccess } = useUpdateDiary();
 
     const { selectedCharacter } = useSelectedCharacterStore();
 
@@ -38,8 +38,6 @@ const WriteDoneButtonLayout = () => {
     const t = useTranslationWithParentName('pages.diaryWritePage.writeDoneButtonLayout');
     const commonT = useTranslationWithParentName('common');
     const loginT = useTranslationWithParentName('login');
-
-    const isMutateLoading: boolean = isCreateMutateLoading || isUpdateMutateLoading;
     const isMutateSuccess: boolean = isCreateMutationSuccess || isUpdateMutationSuccess;
 
     const isNextButtonEnabled = content.length > 0 && ! isWorking;
@@ -47,13 +45,11 @@ const WriteDoneButtonLayout = () => {
     useEffectWithErrorHandling(() => {
         if (isWorking) return;
 
-        if (isMutateLoading) return;
-
         if (! isMutateSuccess) return;
 
         showSuccessToast(t('diaryCreated'));
         navigation.navigate('DiaryTimelinePage');
-    }, [isWorking, isMutateLoading, isMutateSuccess]);
+    }, [isWorking, isMutateSuccess]);
 
     const handleWriteDoneButtonPress = functionWithErrorHandling(() => {
         if (accountState !== AccountStatus.LOGINED) {

--- a/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout.tsx
@@ -75,7 +75,7 @@ const WriteDoneButtonLayout = () => {
             throw new SelectedCharacterNotExistError(t("pleaseSelectCharacter"));
         }
 
-        if (isWorking) return;
+        if (! isNextButtonEnabled) return;
 
         setIsWorking(true);
 


### PR DESCRIPTION
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### HOTFIX
---
* 구현 내용

1. 일기 생성 실패 시에 error throwing이 안 되어서 error toast가 안 되고 바로 success Toast가 되던 오류를 수정함
useEffect를 통해 mutate의 isSuccess가 바뀐 이후 로직이 수행되도록 구성

2. content = "" (빈문자열)임에도 Done 버튼이 작동하던 버그를 수정함

* 추가 발생한 문제(논의 사항)

1. 추후 mutate과 관련하여 로직이 복잡해지는 문제를 멘토링을 통해 해결할 필요성은 있어보임
2. 일기 작성 정책을 결정해야 함
3. Toast message를 보여줄 때 error message를 같이 보여주어도 괜찮을 것 같음 (현재는 이유를 알 수 없어서 사용자가 답답해할 가능성이 높음)