### PR TITLE
[feat] KeyboardAwareContainer, YellowWideButton을 통한 로직 통일 & [bug] Android KeyboardAvoidingView 에러 해결

### DIFF
--- a/fourtoon-cookie/src/components/common/KeyboardAwareContainer.tsx
+++ b/fourtoon-cookie/src/components/common/KeyboardAwareContainer.tsx
@@ -1,0 +1,33 @@
+import { KeyboardAvoidingView, Platform, StyleSheet } from "react-native"
+import { OS } from "../../types/os";
+
+
+export interface KeyboardAwareContainerProps {
+    children?: React.ReactNode;
+}
+
+const KeyboardAwareContainer = (props: KeyboardAwareContainerProps) => {
+    const { children, ...rest } = props;
+
+    return (
+        <KeyboardAvoidingView 
+            style={styles.bottomContainer} 
+            enabled={true}
+            keyboardVerticalOffset={80}
+            behavior={(Platform.OS == OS.IOS) ? 'padding' : 'height'}
+        >
+            {children}
+        </KeyboardAvoidingView>
+    );
+}
+
+export default KeyboardAwareContainer;
+
+const styles = StyleSheet.create({
+    bottomContainer: {
+        position: 'absolute',
+        bottom: 20,
+        left: 20,
+        right: 20,
+    },
+});

--- a/fourtoon-cookie/src/components/common/YellowWideButton.tsx
+++ b/fourtoon-cookie/src/components/common/YellowWideButton.tsx
@@ -1,0 +1,42 @@
+import { StyleSheet } from "react-native";
+import Button from "../../components/common/Button";
+import { useTranslationWithParentName } from "../../hooks/locale";
+
+export interface YellowWideButtonProps {
+    isNextAvailabe: boolean;
+    onNextButtonClick: () => void;
+}
+
+const YellowWideButton = (props: YellowWideButtonProps) => {
+    const { isNextAvailabe, onNextButtonClick, ...rest } = props;
+
+    const commonT = useTranslationWithParentName('common');
+
+    return (
+        <Button
+            title={commonT('done')}
+            onPress={onNextButtonClick}
+            style={{
+                ...styles.nextButton, 
+                backgroundColor: isNextAvailabe ? '#FFC426' : '#DDDDDD'
+            }}
+            textStyle={styles.nextButtonText}
+        />
+    )
+}
+
+export default YellowWideButton;
+
+const styles = StyleSheet.create({
+    nextButton: {
+      width: '100%',
+      height: 60,
+      borderRadius: 16,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    nextButtonText: {
+      fontSize: 17,
+      fontWeight: '600'
+    }
+});

--- a/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/WriteDoneButtonLayout.tsx
@@ -1,12 +1,9 @@
-import { Alert, KeyboardAvoidingView, Platform, StyleSheet } from "react-native"
-import { LocalDate } from "@js-joda/core";
+import { Alert } from "react-native"
 import { useState } from "react";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
-import { OS } from "../../types/os"
 import { Diary, DiaryStatus } from "../../types/diary";
 import { useSelectedCharacterStore } from "../../hooks/store/selectedCharacter";
 import { RootStackParamList } from "../../types/routing";
-import Button from "../../components/common/Button";
 
 import { AccountStatus } from "../../types/account";
 import { useCreateDiary, useUpdateDiary } from "../../hooks/server/diary";
@@ -17,6 +14,8 @@ import { useTranslationWithParentName } from "../../hooks/locale";
 import { SelectedCharacterNotExistError } from "../../types/error/character/SelectedCharacterNotExistError";
 import { showSuccessToast } from "../../system/toast";
 import { useDiaryWritePageContext } from "./DiaryWritePageProvider";
+import KeyboardAwareContainer from "../../components/common/KeyboardAwareContainer";
+import YellowWideButton from "../../components/common/YellowWideButton";
 
 
 const WriteDoneButtonLayout = () => {
@@ -96,43 +95,13 @@ const WriteDoneButtonLayout = () => {
     });
 
     return (
-        <KeyboardAvoidingView 
-            style={styles.bottomContainer} 
-            enabled={true}
-            keyboardVerticalOffset={80}
-            behavior={(Platform.OS == OS.IOS) ? 'padding' : 'height'}
-        >
-            <Button
-                title={commonT('done')}
-                onPress={handleWriteDoneButtonPress}
-                style={{
-                    ...styles.nextButton, 
-                    backgroundColor: isNextButtonEnabled ? '#FFC426' : '#DDDDDD'
-                }}
-                textStyle={styles.nextButtonText}
+        <KeyboardAwareContainer>
+            <YellowWideButton
+                isNextAvailabe={isNextButtonEnabled}
+                onNextButtonClick={handleWriteDoneButtonPress}
             />
-        </KeyboardAvoidingView>
+        </KeyboardAwareContainer>
     )
 }
 
 export default WriteDoneButtonLayout;
-
-const styles = StyleSheet.create({
-    bottomContainer: {
-        position: 'absolute',
-        bottom: 20,
-        left: 20,
-        right: 20,
-      },
-    nextButton: {
-        width: '100%',
-        height: 60,
-        borderRadius: 16,
-        justifyContent: 'center',
-        alignItems: 'center',
-      },
-      nextButtonText: {
-        fontSize: 17,
-        fontWeight: '600'
-      }
-});

--- a/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,15 +1,11 @@
-import { ReactNode, useEffect, useState } from "react";
-import { Gender } from "../../types/gender";
 import ProgressBar from "../../components/common/ProgressBar";
-import { Keyboard, KeyboardAvoidingView, SafeAreaView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView, StyleSheet, View } from "react-native";
 import Header from "./Header";
-import Button from "../../components/common/Button";
 import NameInputLayout from "./NameInputLayout";
 import BirthInputLayout from "./BirthInputLayout";
 import GenderInputLayout from "./GenderInputLayout";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { RootStackParamList } from "../../types/routing";
-import { LocalDate, use } from "@js-joda/core";
 
 import AgreementInputLayout from "./AgreementInputLayout";
 import { useAccountState } from "../../hooks/account";
@@ -17,6 +13,8 @@ import { useFunctionWithErrorHandling } from "../../hooks/error";
 import { useTranslationWithParentName } from "../../hooks/locale";
 import { showSuccessToast } from "../../system/toast";
 import SignUpPageProvider, { SignUpProgres, useSignUpPageContext } from "./SignUpPageProvider";
+import KeyboardAwareContainer from "../../components/common/KeyboardAwareContainer";
+import YellowWideButton from "../../components/common/YellowWideButton";
 
 
 const SignUpPageContent = () => {
@@ -60,12 +58,7 @@ const SignUpPageContent = () => {
                 {signUpProgress == SignUpProgres.BIRTH && <BirthInputLayout />}
                 {signUpProgress == SignUpProgres.GENDER && <GenderInputLayout/>}
                 {signUpProgress == SignUpProgres.AGREEMENT && <AgreementInputLayout />}
-                <KeyboardAvoidingView 
-                    style={styles.bottomContainer} 
-                    enabled={true}
-                    keyboardVerticalOffset={80}
-                    behavior={'padding'}
-                >
+                <KeyboardAwareContainer>
                     <View style={styles.progressContainer}>
                         <ProgressBar
                             progress={signUpProgress}
@@ -73,16 +66,11 @@ const SignUpPageContent = () => {
                             isAnimated={true}
                         />
                     </View>
-                    <Button
-                        title={commonT('next')}
-                        onPress={handleNextButtonClick}
-                        style={{
-                            ...styles.nextButton, 
-                            backgroundColor: isNextAvailabe ? '#FFC426' : '#DDDDDD'
-                        }}
-                        textStyle={styles.nextButtonText}
+                    <YellowWideButton
+                        isNextAvailabe={isNextAvailabe}
+                        onNextButtonClick={handleNextButtonClick}
                     />
-                </KeyboardAvoidingView>
+                </KeyboardAwareContainer>
             </View>
         </SafeAreaView>
     );
@@ -109,24 +97,7 @@ const styles = StyleSheet.create({
       padding: 23,
       position: 'relative'
     },
-    bottomContainer: {
-      position: 'absolute',
-      bottom: 20,
-      left: 20,
-      right: 20,
-    },
     progressContainer: {
       marginBottom: 20,
     },
-    nextButton: {
-      width: '100%',
-      height: 60,
-      borderRadius: 16,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-    nextButtonText: {
-      fontSize: 17,
-      fontWeight: '600'
-    }
 });


### PR DESCRIPTION
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-450
---
* 구현 내용

- KeyboardAvoidingView를 일반화 한 KeyboardAwareContainer 컴포넌트를 구현
- Button을 활용하여 Footer에 자주 있던 노란색 버튼을 YellowWideButton 컴포넌트로 구현
- 위의 두 컴포넌트를 DiaryWritePage, SignUpPage에 적용

+ KeyboardAwareContainer의 세팅을 Android에도 맞춘 설정으로 함으로써 KeyboardAware가 잘 되도록 함

### 화면 예시
---
<img width="382" alt="image" src="https://github.com/user-attachments/assets/9ebb538c-19a6-4993-92e0-820a0d55a94f">
