### PR TITLE
[feat] DiaryWritePage에서 Date 선택 시 Calendar UI를 제공

### DIFF
--- a/fourtoon-cookie/package-lock.json
+++ b/fourtoon-cookie/package-lock.json
@@ -34,6 +34,7 @@
         "react-error-boundary": "^4.0.13",
         "react-i18next": "^15.0.3",
         "react-native": "0.74.5",
+        "react-native-calendars": "^1.1307.0",
         "react-native-get-random-values": "^1.11.0",
         "react-native-modal": "^13.0.1",
         "react-native-modal-datetime-picker": "^17.1.0",
@@ -11964,6 +11965,16 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -13060,6 +13071,24 @@
         "prop-types": "^15.7.2"
       }
     },
+    "node_modules/react-native-calendars": {
+      "version": "1.1307.0",
+      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1307.0.tgz",
+      "integrity": "sha512-Fl9NxPgkXw6aboGOifER8Np+p8im753IUGh1sOy7eMuDAP+x5fSDw1K5GnChdVAKWAdLfsNWFIyYehHChf5vmw==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.1",
+        "lodash": "^4.17.15",
+        "memoize-one": "^5.2.1",
+        "prop-types": "^15.5.10",
+        "react-native-swipe-gestures": "^1.0.5",
+        "recyclerlistview": "^4.0.0",
+        "xdate": "^0.8.0"
+      },
+      "optionalDependencies": {
+        "moment": "^2.29.4"
+      }
+    },
     "node_modules/react-native-get-random-values": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
@@ -13075,6 +13104,7 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-13.0.1.tgz",
       "integrity": "sha512-UB+mjmUtf+miaG/sDhOikRfBOv0gJdBU2ZE1HtFWp6UixW9jCk/bhGdHUgmZljbPpp0RaO/6YiMmQSSK3kkMaw==",
+      "license": "MIT",
       "dependencies": {
         "prop-types": "^15.6.2",
         "react-native-animatable": "1.3.3"
@@ -13151,6 +13181,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/react-native-swipe-gestures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
+      "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
+      "license": "MIT"
     },
     "node_modules/react-native-toast-message": {
       "version": "2.2.1",
@@ -13353,6 +13389,21 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recyclerlistview": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.1.tgz",
+      "integrity": "sha512-NtVYjofwgUCt1rEsTp6jHQg/47TWjnO92TU2kTVgJ9wsc/ely4HnizHHa+f/dI7qaw4+zcSogElrLjhMltN2/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "4.0.8",
+        "prop-types": "15.8.1",
+        "ts-object-utils": "0.0.5"
+      },
+      "peerDependencies": {
+        "react": ">= 15.2.1",
+        "react-native": ">= 0.30.0"
       }
     },
     "node_modules/regenerate": {
@@ -14740,6 +14791,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-object-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
+      "license": "ISC"
+    },
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -15405,6 +15462,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/xdate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.3.tgz",
+      "integrity": "sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==",
+      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/xml2js": {
       "version": "0.6.0",

--- a/fourtoon-cookie/package.json
+++ b/fourtoon-cookie/package.json
@@ -36,6 +36,7 @@
     "react-error-boundary": "^4.0.13",
     "react-i18next": "^15.0.3",
     "react-native": "0.74.5",
+    "react-native-calendars": "^1.1307.0",
     "react-native-get-random-values": "^1.11.0",
     "react-native-modal": "^13.0.1",
     "react-native-modal-datetime-picker": "^17.1.0",

--- a/fourtoon-cookie/src/pages/DiaryWritePage/DateInfo.tsx
+++ b/fourtoon-cookie/src/pages/DiaryWritePage/DateInfo.tsx
@@ -1,18 +1,25 @@
 import React, { useState } from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
+import Modal from 'react-native-modal';
 import DOWN_ARROW from '../../../assets/icon/down-arrow.png';
 
 import { LocalDate } from '@js-joda/core';
 import { useFunctionWithErrorHandling } from '../../hooks/error';
 import { useDiaryWritePageContext } from './DiaryWritePageProvider';
+import { Calendar, DateData } from 'react-native-calendars';
+import Button from '../../components/common/Button';
+import { useTranslationWithParentName } from '../../hooks/locale';
 
 const DateInfo = () => {
     const { currentDiaryId, diaryDate, setDiaryDate } = useDiaryWritePageContext();
 
+    const [ selectedDate, setSelectedDate ] = useState<LocalDate>(LocalDate.now());
     const [isDatePickerVisible, setDatePickerVisible] = useState<boolean>(false);
 
     const { functionWithErrorHandling } = useFunctionWithErrorHandling();
+
+    const commonT = useTranslationWithParentName('common');
 
     const isChangeable: boolean = ! currentDiaryId;
     const dateString: string = diaryDate.toString();
@@ -22,17 +29,18 @@ const DateInfo = () => {
         setDatePickerVisible(true);
     });
 
-    const handleCancel = functionWithErrorHandling(() => {
+    const handleClose = functionWithErrorHandling(() => {
         setDatePickerVisible(false);
     })
 
-    const handleConfirm = functionWithErrorHandling((date: Date) => {
-        if (date.getTime() > Date.now()) return;
-        const localDate: LocalDate = LocalDate.of(date.getFullYear(), date.getMonth() + 1, date.getDate());
-        setDiaryDate(localDate);
-        setDatePickerVisible(false);
+    const handleDayPress = functionWithErrorHandling((date: DateData) => {
+        setSelectedDate(LocalDate.parse(date.dateString));
     })
 
+    const handleDone = functionWithErrorHandling(() => {
+        setDiaryDate(selectedDate);
+        handleClose();
+    });
 
     return (
         <View style={styles.container}>
@@ -40,14 +48,29 @@ const DateInfo = () => {
                 <Text style={styles.date}>{dateString}</Text>
                 <Image source={DOWN_ARROW} style={styles.downArrow} />
             </TouchableOpacity>
-            <DateTimePickerModal 
+            <Modal 
                 isVisible={isDatePickerVisible}
-                mode="date"
-                date={new Date(diaryDate.year(), diaryDate.monthValue() - 1, diaryDate.dayOfMonth())}
-                onConfirm={handleConfirm}
-                onCancel={handleCancel}
-                style={styles.dateModal}
-            />
+                onBackdropPress={handleClose}
+                onBackButtonPress={handleClose}
+            >
+                <View style={styles.dateModal}>
+                    <View style={styles.dateModalCalender}>
+                        <Calendar
+                            current={selectedDate.toString()}
+                            onDayPress={handleDayPress}
+                            markedDates={{
+                                [selectedDate.toString()]: {
+                                    selected: true, 
+                                    selectedColor: '#FFC426'
+                                }
+                            }}
+                            theme={{arrowColor: '#FFC426'}}
+                            maxDate={LocalDate.now().toString()}
+                        />
+                    </View>
+                    <Button title={commonT('done')} onPress={handleDone} style={styles.dateModalButton}/>
+                </View>
+            </Modal>
         </View>
     );
 };
@@ -79,6 +102,21 @@ const styles = StyleSheet.create({
         marginLeft: 10,
     },
     dateModal: {
-        position: "absolute"
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: 16,
+        backgroundColor: 'white',
+    },
+    dateModalCalender: {
+        width: '90%'
+    },
+    dateModalButton: {
+        width: '100%',
+        height: 60,
+        borderRadius: 16,
+        marginTop: 20,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#FFC426',
     }
 });


### PR DESCRIPTION
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-448
---
* 구현 내용

react-native-calendars 의존성 추가함

위의 패키지를 활용하여 화면과 같이 괜찮은 캘린더 UI가 나오도록 컴포넌트를 교체

* 추가 발생한 문제(논의 사항)

- 회원가입 페이지에서의 날짜 선택 UI를 개선할 필요성이 매우 있음
- 마이(SettingPage)에서 캘린더로 일기 작성 현황을 보여줘도 좋을 것 같음

### 화면 예시
---

![5E7068B6-95B8-4072-8B43-2F2CAFD17631_1_102_o](https://github.com/user-attachments/assets/aac8b5c9-8e10-401c-915d-bcd1372585b4)
